### PR TITLE
Change the signature of the call() method

### DIFF
--- a/src/flickr_photos_api/exceptions.py
+++ b/src/flickr_photos_api/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Dict, Optional, Union
 
 
 class FlickrApiException(Exception):
@@ -14,7 +14,7 @@ class ResourceNotFound(FlickrApiException):
     Thrown when you try to look up a resource that doesn't exist.
     """
 
-    def __init__(self, method: str, **params: Union[str, int]):
+    def __init__(self, method: str, params: Optional[Dict[str, Union[str, int]]]):
         super().__init__(
             f"Unable to find resource at {method} with properties {params}"
         )


### PR DESCRIPTION
This makes it more consistent with other HTTP-like APIs in Python (and elsewhere in Flickr Foundation codebases).

This is an internal-only API, so I'm not going to cut a release for this. This doesn't count as a breaking change IMO.