### PR TITLE
Fix a bug where looking up videos could throw a ValueError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.8.1 - 2024-03-21
+
+*   Fix a bug where looking up videos could throw a ValueError.
+
 ## v1.8.0 - 2024-01-09
 
 *   Fix a bug where some photos would be returned with location information, even though the location accuracy is `0`, which means it's so vague as to be unusable.

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -26,7 +26,7 @@ from .types import (
 )
 
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 
 __all__ = [

--- a/src/flickr_photos_api/api.py
+++ b/src/flickr_photos_api/api.py
@@ -420,15 +420,39 @@ class FlickrPhotosApi(BaseApi):
         sizes: list[Size] = []
 
         for s in sizes_resp.findall(".//size"):
-            sizes.append(
-                {
-                    "label": s.attrib["label"],
-                    "width": int(s.attrib["width"]),
-                    "height": int(s.attrib["height"]),
-                    "media": s.attrib["media"],
-                    "source": s.attrib["source"],
-                }
-            )
+            if s.attrib["media"] == "photo":
+                sizes.append(
+                    {
+                        "label": s.attrib["label"],
+                        "width": int(s.attrib["width"]),
+                        "height": int(s.attrib["height"]),
+                        "media": "photo",
+                        "source": s.attrib["source"],
+                    }
+                )
+
+            elif s.attrib["media"] == "video":
+                try:
+                    width = int(s.attrib["width"])
+                except ValueError:
+                    width = None
+
+                try:
+                    height = int(s.attrib["height"])
+                except ValueError:
+                    height = None
+
+                sizes.append(
+                    {
+                        "label": s.attrib["label"],
+                        "width": width,
+                        "height": height,
+                        "media": "video",
+                        "source": s.attrib["source"],
+                    }
+                )
+            else:  # pragma: no cover
+                raise ValueError(f"Unrecognised media type: {s.attrib['media']}")
 
         # We have two options with tags: we can use the 'raw' version
         # entered by the user, or we can use the normalised version in

--- a/src/flickr_photos_api/types.py
+++ b/src/flickr_photos_api/types.py
@@ -34,13 +34,6 @@ class DateTaken(TypedDict):
     granularity: TakenGranularity
 
 
-class NewSize(TypedDict):
-    width: int
-    height: int
-    media: str
-    source: str
-
-
 class Size(TypedDict):
     label: str
     width: int

--- a/src/flickr_photos_api/types.py
+++ b/src/flickr_photos_api/types.py
@@ -36,9 +36,9 @@ class DateTaken(TypedDict):
 
 class Size(TypedDict):
     label: str
-    width: int
-    height: int
-    media: str
+    width: int | None
+    height: int | None
+    media: Literal["photo", "video"]
     source: str
 
 

--- a/src/flickr_photos_api/utils.py
+++ b/src/flickr_photos_api/utils.py
@@ -122,12 +122,17 @@ def parse_sizes(photo_elem: ET.Element) -> list[Size]:
         ("o", "Original"),
     ]:
         try:
+            media = photo_elem.attrib["media"]
+
+            if media not in ("video", "photo"):  # pragma: no cover
+                raise ValueError(f"Unrecognised media: {media!r}")
+
             sizes.append(
                 {
                     "height": int(photo_elem.attrib[f"height_{suffix}"]),
                     "width": int(photo_elem.attrib[f"width_{suffix}"]),
                     "label": label,
-                    "media": photo_elem.attrib["media"],
+                    "media": media,  # type: ignore
                     "source": photo_elem.attrib[f"url_{suffix}"],
                 }
             )

--- a/tests/fixtures/cassettes/TestCollectionsPhotoResponse.test_can_get_collection_with_videos.yml
+++ b/tests/fixtures/cassettes/TestCollectionsPhotoResponse.test_can_get_collection_with_videos.yml
@@ -1,0 +1,431 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupUser&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fbrampitoyo%2F
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<user
+      id=\"91178292@N00\">\n\t<username>Bram Pitoyo</username>\n</user>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 21 Mar 2024 12:06:33 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 cebcb0d17c62ea30e361587bfe114ca0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - SG9XtQ_WQ4VLBLxsqjSJnFS4tDZSfb8pFlGKpux_QxW3-psDog4-BA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-65fc22c9-141be12d611df6724ab1f4b6;Root=1-65fc22c9-3a1d0b4906cd7b1704d40f3c
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.34.97
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=91178292%40N00
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"91178292@N00\" nsid=\"91178292@N00\" ispro=\"0\" is_deleted=\"0\" iconserver=\"4366\"
+      iconfarm=\"5\" path_alias=\"brampitoyo\" has_stats=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\"
+      has_free_educational_resources=\"0\">\n\t<username>Bram Pitoyo</username>\n\t<realname>Bram
+      Pitoyo</realname>\n\t<location>Wellington, New Zealand</location>\n\t<timezone
+      label=\"Auckland, Wellington\" offset=\"+12:00\" timezone_id=\"Pacific/Auckland\"
+      timezone=\"73\" />\n\t<description>At Mozilla, Bram Pitoyo is a design strategist
+      &amp;amp; typographer who works at the nexus of user experience, architecture,
+      community engagement &amp;amp; most other subjects.</description>\n\t<photosurl>https://www.flickr.com/photos/brampitoyo/</photosurl>\n\t<profileurl>https://www.flickr.com/people/brampitoyo/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/brampitoyo/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2007-04-30
+      22:42:16</firstdatetaken>\n\t\t<firstdate>1178498861</firstdate>\n\t\t<count>1352</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 21 Mar 2024 12:06:33 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 cebcb0d17c62ea30e361587bfe114ca0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 2JOL6mvU28APYmuBvxguKKy43tlGwjQv-fq-bB4Lv-U4d4vO070KFA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-65fc22c9-6956e2b6669a0b97455556b4;Root=1-65fc22c9-4e1577f96a91942f26ff24df
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.31.184
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Coriginal_format%2Cowner_name%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o%2Ctags%2Cgeo%2Curl_q%2Curl_l%2Cdescription%2Csafety_level%2Crealname&method=flickr.photosets.getPhotos&page=1&per_page=10&photoset_id=72157624715342071&user_id=91178292%40N00
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photoset
+      id=\"72157624715342071\" primary=\"4941540830\" owner=\"91178292@N00\" ownername=\"Bram
+      Pitoyo\" page=\"1\" per_page=\"10\" perpage=\"10\" pages=\"5\" title=\"Delhi
+      Life\" total=\"42\">\n\t<photo id=\"4941540830\" secret=\"3133850cf5\" server=\"4141\"
+      farm=\"5\" title=\"Sit\" isprimary=\"1\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" safety_level=\"0\" dateupload=\"1283169092\" datetaken=\"2010-08-28
+      13:08:01\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Bram
+      Pitoyo\" realname=\"Bram Pitoyo\" tags=\"india market delhi 0stars\" originalsecret=\"0d1a994712\"
+      originalformat=\"jpg\" latitude=\"28.656738\" longitude=\"77.230796\" accuracy=\"14\"
+      context=\"0\" place_id=\"q3sUR5FTW7i1W2jYtA\" woeid=\"29215723\" geo_is_public=\"1\"
+      geo_is_contact=\"0\" geo_is_friend=\"0\" geo_is_family=\"0\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/4141/4941540830_3133850cf5_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/4141/4941540830_3133850cf5_t.jpg\"
+      height_t=\"100\" width_t=\"75\" url_s=\"https://live.staticflickr.com/4141/4941540830_3133850cf5_m.jpg\"
+      height_s=\"240\" width_s=\"180\" url_m=\"https://live.staticflickr.com/4141/4941540830_3133850cf5.jpg\"
+      height_m=\"500\" width_m=\"375\" url_o=\"https://live.staticflickr.com/4141/4941540830_0d1a994712_o.jpg\"
+      height_o=\"2048\" width_o=\"1536\" url_q=\"https://live.staticflickr.com/4141/4941540830_3133850cf5_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/4141/4941540830_3133850cf5_b.jpg\"
+      height_l=\"1024\" width_l=\"768\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"4960846396\" secret=\"9b7f74ef31\" server=\"4128\" farm=\"5\" title=\"Jama
+      Masjid, 360\xB0\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" safety_level=\"0\" dateupload=\"1283705910\" datetaken=\"2010-09-05
+      09:58:30\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Bram
+      Pitoyo\" realname=\"Bram Pitoyo\" tags=\"india delhi mosque masjid jama\" originalsecret=\"d19e9b8310\"
+      originalformat=\"jpg\" latitude=\"28.650448\" longitude=\"77.236461\" accuracy=\"14\"
+      context=\"0\" place_id=\"ZTb_BxtTW7hO5U6iOw\" woeid=\"29215720\" geo_is_public=\"1\"
+      geo_is_contact=\"0\" geo_is_friend=\"0\" geo_is_family=\"0\" media=\"video\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/4128/4960846396_9b7f74ef31_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/4128/4960846396_9b7f74ef31_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/4128/4960846396_9b7f74ef31_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/4128/4960846396_9b7f74ef31.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/4128/4960846396_d19e9b8310_o.jpg\"
+      height_o=\"480\" width_o=\"640\" url_q=\"https://live.staticflickr.com/4128/4960846396_9b7f74ef31_q.jpg\"
+      height_q=\"150\" width_q=\"150\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"4960311501\" secret=\"6c4b23389f\" server=\"4146\" farm=\"5\" title=\"Shri
+      Khandelwal Digamber Jain Mandir, 360\xB0\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" license=\"0\" safety_level=\"0\" dateupload=\"1283707065\" datetaken=\"2010-09-05
+      10:17:45\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Bram
+      Pitoyo\" realname=\"Bram Pitoyo\" tags=\"india temple delhi jain mandir shri
+      khandelwal digamber\" originalsecret=\"0a97208a7f\" originalformat=\"jpg\" latitude=\"28.632158\"
+      longitude=\"77.212740\" accuracy=\"16\" context=\"0\" place_id=\"fxou5X5TW7g0RFlelw\"
+      woeid=\"29216074\" geo_is_public=\"1\" geo_is_contact=\"0\" geo_is_friend=\"0\"
+      geo_is_family=\"0\" media=\"video\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/4146/4960311501_6c4b23389f_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/4146/4960311501_6c4b23389f_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/4146/4960311501_6c4b23389f_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/4146/4960311501_6c4b23389f.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/4146/4960311501_0a97208a7f_o.jpg\"
+      height_o=\"480\" width_o=\"640\" url_q=\"https://live.staticflickr.com/4146/4960311501_6c4b23389f_q.jpg\"
+      height_q=\"150\" width_q=\"150\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"4960396261\" secret=\"18120df31a\" server=\"4118\" farm=\"5\" title=\"Chandni
+      Chowk Bazaar, 360\xB0\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" safety_level=\"0\" dateupload=\"1283708608\" datetaken=\"2010-09-05
+      10:43:28\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Bram
+      Pitoyo\" realname=\"Bram Pitoyo\" tags=\"india market delhi bazaar chandni chowk\"
+      originalsecret=\"db574f5a7d\" originalformat=\"jpg\" latitude=\"28.656738\"
+      longitude=\"77.230796\" accuracy=\"14\" context=\"0\" place_id=\"q3sUR5FTW7i1W2jYtA\"
+      woeid=\"29215723\" geo_is_public=\"1\" geo_is_contact=\"0\" geo_is_friend=\"0\"
+      geo_is_family=\"0\" media=\"video\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/4118/4960396261_18120df31a_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/4118/4960396261_18120df31a_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/4118/4960396261_18120df31a_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/4118/4960396261_18120df31a.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/4118/4960396261_db574f5a7d_o.jpg\"
+      height_o=\"480\" width_o=\"640\" url_q=\"https://live.staticflickr.com/4118/4960396261_18120df31a_q.jpg\"
+      height_q=\"150\" width_q=\"150\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"4985254293\" secret=\"ee24906304\" server=\"4127\" farm=\"5\" title=\"Auto
+      Rickshaw\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\"
+      safety_level=\"0\" dateupload=\"1284357835\" datetaken=\"2010-09-02 18:14:43\"
+      datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Bram Pitoyo\"
+      realname=\"Bram Pitoyo\" tags=\"auto delhi rickshaw 0stars\" originalsecret=\"7fd5b42a02\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/4127/4985254293_ee24906304_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/4127/4985254293_ee24906304_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/4127/4985254293_ee24906304_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/4127/4985254293_ee24906304.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/4127/4985254293_7fd5b42a02_o.jpg\"
+      height_o=\"1536\" width_o=\"2048\" url_q=\"https://live.staticflickr.com/4127/4985254293_ee24906304_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/4127/4985254293_ee24906304_b.jpg\"
+      height_l=\"768\" width_l=\"1024\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"4985860228\" secret=\"12a3ea557c\" server=\"4148\" farm=\"5\" title=\"Josh\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" safety_level=\"0\"
+      dateupload=\"1284358014\" datetaken=\"2010-09-02 16:48:43\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"Bram Pitoyo\" realname=\"Bram Pitoyo\" tags=\"delhi
+      tomb safdarjang 0stars\" originalsecret=\"90fed2b97f\" originalformat=\"jpg\"
+      latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/4148/4985860228_12a3ea557c_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/4148/4985860228_12a3ea557c_t.jpg\"
+      height_t=\"100\" width_t=\"75\" url_s=\"https://live.staticflickr.com/4148/4985860228_12a3ea557c_m.jpg\"
+      height_s=\"240\" width_s=\"180\" url_m=\"https://live.staticflickr.com/4148/4985860228_12a3ea557c.jpg\"
+      height_m=\"500\" width_m=\"375\" url_o=\"https://live.staticflickr.com/4148/4985860228_90fed2b97f_o.jpg\"
+      height_o=\"2048\" width_o=\"1536\" url_q=\"https://live.staticflickr.com/4148/4985860228_12a3ea557c_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/4148/4985860228_12a3ea557c_b.jpg\"
+      height_l=\"1024\" width_l=\"768\">\n\t\t<description>\n\nJosh and my W+K coworker
+      Sarah, both from the UK, were kind enough to let me crash at their flat on my
+      first week in Delhi. </description>\n\t</photo>\n\t<photo id=\"4985266441\"
+      secret=\"e96ee69eee\" server=\"4151\" farm=\"5\" title=\"W+K Delhi Kissing Booths\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"0\" safety_level=\"0\"
+      dateupload=\"1284358232\" datetaken=\"2010-08-31 19:33:30\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"Bram Pitoyo\" realname=\"Bram Pitoyo\" tags=\"booth
+      kissing delhi wk kennedy wieden wiedenkennedy 0stars\" originalsecret=\"5a6c93939b\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/4151/4985266441_e96ee69eee_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/4151/4985266441_e96ee69eee_t.jpg\"
+      height_t=\"100\" width_t=\"75\" url_s=\"https://live.staticflickr.com/4151/4985266441_e96ee69eee_m.jpg\"
+      height_s=\"240\" width_s=\"180\" url_m=\"https://live.staticflickr.com/4151/4985266441_e96ee69eee.jpg\"
+      height_m=\"500\" width_m=\"375\" url_o=\"https://live.staticflickr.com/4151/4985266441_5a6c93939b_o.jpg\"
+      height_o=\"2048\" width_o=\"1536\" url_q=\"https://live.staticflickr.com/4151/4985266441_e96ee69eee_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/4151/4985266441_e96ee69eee_b.jpg\"
+      height_l=\"1024\" width_l=\"768\">\n\t\t<description>\n\nIncidentally double
+      as meeting rooms.</description>\n\t</photo>\n\t<photo id=\"4995610460\" secret=\"000ff71900\"
+      server=\"4091\" farm=\"5\" title=\"Open Frame: International Film Festival &amp;
+      Forum on people, politics and rights\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" license=\"0\" safety_level=\"0\" dateupload=\"1284628434\" datetaken=\"2010-09-12
+      16:45:26\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Bram
+      Pitoyo\" realname=\"Bram Pitoyo\" tags=\"film festival delhi openframe psbt
+      0stars\" originalsecret=\"ca44e79f29\" originalformat=\"jpg\" latitude=\"0\"
+      longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/4091/4995610460_000ff71900_s.jpg\" height_sq=\"75\"
+      width_sq=\"75\" url_t=\"https://live.staticflickr.com/4091/4995610460_000ff71900_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/4091/4995610460_000ff71900_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/4091/4995610460_000ff71900.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/4091/4995610460_ca44e79f29_o.jpg\"
+      height_o=\"1536\" width_o=\"2048\" url_q=\"https://live.staticflickr.com/4091/4995610460_000ff71900_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/4091/4995610460_000ff71900_b.jpg\"
+      height_l=\"768\" width_l=\"1024\">\n\t\t<description>\n\nThink of this India
+      Habitat Centre venue as every art gallery, experimental theatre and smallish
+      performing art space in Downtown Portland and The Pearl rolled into one huge,
+      multi-storied complex. It\u2019s the closest thing I have to Portland\u2019s
+      vibrant art scene, perhaps minus the actual smallness and relentless independent
+      spirit, and plus a whole lot of expats.</description>\n\t</photo>\n\t<photo
+      id=\"4995613334\" secret=\"980d93abc5\" server=\"4154\" farm=\"5\" title=\"Sarah
+      Coles, the Delhi host\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"0\" safety_level=\"0\" dateupload=\"1284628560\" datetaken=\"2010-09-11
+      21:15:22\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Bram
+      Pitoyo\" realname=\"Bram Pitoyo\" tags=\"india delhi host 0stars sarahcoles\"
+      originalsecret=\"0829fb0536\" originalformat=\"jpg\" latitude=\"0\" longitude=\"0\"
+      accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/4154/4995613334_980d93abc5_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/4154/4995613334_980d93abc5_t.jpg\"
+      height_t=\"100\" width_t=\"75\" url_s=\"https://live.staticflickr.com/4154/4995613334_980d93abc5_m.jpg\"
+      height_s=\"240\" width_s=\"180\" url_m=\"https://live.staticflickr.com/4154/4995613334_980d93abc5.jpg\"
+      height_m=\"500\" width_m=\"375\" url_o=\"https://live.staticflickr.com/4154/4995613334_0829fb0536_o.jpg\"
+      height_o=\"2048\" width_o=\"1536\" url_q=\"https://live.staticflickr.com/4154/4995613334_980d93abc5_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/4154/4995613334_980d93abc5_b.jpg\"
+      height_l=\"1024\" width_l=\"768\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"5579683674\" secret=\"4cc02d8ac5\" server=\"5301\" farm=\"6\" title=\"Dance\"
+      isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"5\" safety_level=\"0\"
+      dateupload=\"1301666006\" datetaken=\"2011-04-01 06:53:26\" datetakengranularity=\"0\"
+      datetakenunknown=\"0\" ownername=\"Bram Pitoyo\" realname=\"Bram Pitoyo\" tags=\"wedding
+      india dance delhi punjabi\" originalsecret=\"6c384a42ea\" originalformat=\"jpg\"
+      latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"video\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/5301/5579683674_4cc02d8ac5_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/5301/5579683674_4cc02d8ac5_t.jpg\"
+      height_t=\"75\" width_t=\"100\" url_s=\"https://live.staticflickr.com/5301/5579683674_4cc02d8ac5_m.jpg\"
+      height_s=\"180\" width_s=\"240\" url_m=\"https://live.staticflickr.com/5301/5579683674_4cc02d8ac5.jpg\"
+      height_m=\"375\" width_m=\"500\" url_o=\"https://live.staticflickr.com/5301/5579683674_6c384a42ea_o.jpg\"
+      height_o=\"480\" width_o=\"640\" url_q=\"https://live.staticflickr.com/5301/5579683674_4cc02d8ac5_q.jpg\"
+      height_q=\"150\" width_q=\"150\">\n\t\t<description />\n\t</photo>\n</photoset>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 21 Mar 2024 12:06:34 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 cebcb0d17c62ea30e361587bfe114ca0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - HbBZztajYz94BHsz-s0z9_uYWoB_int5H-oT8xd4H7UaV-HoB22kDQ==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-65fc22c9-64c5711a0db822e414e97a33;Root=1-65fc22c9-2cc1b124433ad4eb283edf57
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.10.17
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
+      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
+      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+      />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 21 Mar 2024 12:06:34 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 cebcb0d17c62ea30e361587bfe114ca0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - OhJC6n9tmGmn6DRTNx_OI8MzajqgY5escJdXCdYYMZmcU3DOOq5qvg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-65fc22ca-6e1dc1957d83f1f96f73cf08;Root=1-65fc22ca-792ed5110310995d6310762b
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.34.97
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photosets.getInfo&photoset_id=72157624715342071&user_id=91178292%40N00
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photoset
+      id=\"72157624715342071\" owner=\"91178292@N00\" username=\"Bram Pitoyo\" primary=\"4941540830\"
+      secret=\"3133850cf5\" server=\"4141\" farm=\"5\" count_views=\"56\" count_comments=\"0\"
+      count_photos=\"20\" count_videos=\"22\" can_comment=\"0\" date_create=\"1283170688\"
+      date_update=\"1343090408\" photos=\"42\" visibility_can_see_set=\"1\" needs_interstitial=\"0\">\n\t<title>Delhi
+      Life</title>\n\t<description />\n</photoset>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 21 Mar 2024 12:06:34 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 cebcb0d17c62ea30e361587bfe114ca0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - A645CVPz-WVMYSOyWgwWDeTLIUptHVagcfPjLLnK8LGwduoefIgEAA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-65fc22ca-5e28911f2069229b1e518874;Root=1-65fc22ca-6cab8c7317b80cde6e132771
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.34.97
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestGetSinglePhoto.test_it_can_get_a_video.yml
+++ b/tests/fixtures/cassettes/TestGetSinglePhoto.test_it_can_get_a_video.yml
@@ -1,0 +1,220 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=4960396261
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photo
+      id=\"4960396261\" secret=\"18120df31a\" server=\"4118\" farm=\"5\" dateuploaded=\"1283708608\"
+      isfavorite=\"0\" license=\"0\" safety_level=\"0\" rotation=\"0\" originalsecret=\"db574f5a7d\"
+      originalformat=\"jpg\" views=\"486\" media=\"video\">\n\t<owner nsid=\"91178292@N00\"
+      username=\"Bram Pitoyo\" realname=\"Bram Pitoyo\" location=\"Wellington, New
+      Zealand\" iconserver=\"4366\" iconfarm=\"5\" path_alias=\"brampitoyo\">\n\t\t<gift
+      gift_eligible=\"1\" new_flow=\"1\">\n\t\t\t<eligible_durations />\n\t\t\t<eligible_durations
+      />\n\t\t\t<eligible_durations />\n\t\t</gift>\n\t</owner>\n\t<title>Chandni
+      Chowk Bazaar, 360\xB0</title>\n\t<description />\n\t<visibility ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" />\n\t<dates posted=\"1283708608\" taken=\"2010-09-05
+      10:43:28\" takengranularity=\"0\" takenunknown=\"0\" lastupdate=\"1283787057\"
+      />\n\t<editability cancomment=\"0\" canaddmeta=\"0\" />\n\t<publiceditability
+      cancomment=\"1\" canaddmeta=\"0\" />\n\t<usage candownload=\"1\" canblog=\"0\"
+      canprint=\"0\" canshare=\"1\" />\n\t<comments>2</comments>\n\t<notes />\n\t<people
+      haspeople=\"0\" />\n\t<tags>\n\t\t<tag id=\"5127903-4960396261-5898\" author=\"91178292@N00\"
+      authorname=\"Bram Pitoyo\" raw=\"Delhi\" machine_tag=\"0\">delhi</tag>\n\t\t<tag
+      id=\"5127903-4960396261-393\" author=\"91178292@N00\" authorname=\"Bram Pitoyo\"
+      raw=\"India\" machine_tag=\"0\">india</tag>\n\t\t<tag id=\"5127903-4960396261-362057\"
+      author=\"91178292@N00\" authorname=\"Bram Pitoyo\" raw=\"Chandni\" machine_tag=\"0\">chandni</tag>\n\t\t<tag
+      id=\"5127903-4960396261-362058\" author=\"91178292@N00\" authorname=\"Bram Pitoyo\"
+      raw=\"Chowk\" machine_tag=\"0\">chowk</tag>\n\t\t<tag id=\"5127903-4960396261-26234\"
+      author=\"91178292@N00\" authorname=\"Bram Pitoyo\" raw=\"bazaar\" machine_tag=\"0\">bazaar</tag>\n\t\t<tag
+      id=\"5127903-4960396261-4566\" author=\"91178292@N00\" authorname=\"Bram Pitoyo\"
+      raw=\"market\" machine_tag=\"0\">market</tag>\n\t</tags>\n\t<location latitude=\"28.656738\"
+      longitude=\"77.230796\" accuracy=\"14\" context=\"0\">\n\t\t<locality woeid=\"2295019\">New
+      Delhi</locality>\n\t\t<county woeid=\"28743737\">Central Delhi</county>\n\t\t<region
+      woeid=\"20070458\">Delhi</region>\n\t\t<country woeid=\"23424848\">India</country>\n\t\t<neighbourhood
+      woeid=\"29215723\">Chandni Chowk Area</neighbourhood>\n\t</location>\n\t<geoperms
+      ispublic=\"1\" iscontact=\"0\" isfriend=\"0\" isfamily=\"0\" />\n\t<urls>\n\t\t<url
+      type=\"photopage\">https://www.flickr.com/photos/brampitoyo/4960396261/</url>\n\t</urls>\n\t<video
+      ready=\"1\" failed=\"0\" pending=\"0\" duration=\"23\" width=\"640\" height=\"480\"
+      />\n</photo>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 21 Mar 2024 12:03:39 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 a4fe4605acede182bb5c399b9c69b8c4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 7Axj2pMhCqk4oAZDH3z-I_ic_NJhzayOgVl8M74o6pm-dwTCzhZzjA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-65fc221b-72417443156ef7662c19d6bd;Root=1-65fc221b-127406b3699532f45618ab11
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.5.219
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=4960396261
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<sizes
+      canblog=\"0\" canprint=\"0\" candownload=\"1\">\n\t<size label=\"Square\" width=\"75\"
+      height=\"75\" source=\"https://live.staticflickr.com/4118/4960396261_18120df31a_s.jpg\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/sizes/sq/\" media=\"photo\"
+      />\n\t<size label=\"Large Square\" width=\"150\" height=\"150\" source=\"https://live.staticflickr.com/4118/4960396261_18120df31a_q.jpg\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/sizes/q/\" media=\"photo\"
+      />\n\t<size label=\"Thumbnail\" width=\"100\" height=\"75\" source=\"https://live.staticflickr.com/4118/4960396261_18120df31a_t.jpg\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/sizes/t/\" media=\"photo\"
+      />\n\t<size label=\"Small\" width=\"240\" height=\"180\" source=\"https://live.staticflickr.com/4118/4960396261_18120df31a_m.jpg\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/sizes/s/\" media=\"photo\"
+      />\n\t<size label=\"Small 320\" width=\"320\" height=\"240\" source=\"https://live.staticflickr.com/4118/4960396261_18120df31a_n.jpg\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/sizes/n/\" media=\"photo\"
+      />\n\t<size label=\"Small 400\" width=\"400\" height=\"300\" source=\"https://live.staticflickr.com/4118/4960396261_18120df31a_w.jpg\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/sizes/w/\" media=\"photo\"
+      />\n\t<size label=\"Medium\" width=\"500\" height=\"375\" source=\"https://live.staticflickr.com/4118/4960396261_18120df31a.jpg\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/sizes/m/\" media=\"photo\"
+      />\n\t<size label=\"Medium 640\" width=\"640\" height=\"480\" source=\"https://live.staticflickr.com/4118/4960396261_18120df31a_z.jpg\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/sizes/z/\" media=\"photo\"
+      />\n\t<size label=\"Original\" width=\"640\" height=\"480\" source=\"https://live.staticflickr.com/4118/4960396261_db574f5a7d_o.jpg\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/sizes/o/\" media=\"photo\"
+      />\n\t<size label=\"Video Player\" width=\"640\" height=\"480\" source=\"https://www.flickr.com/apps/video/stewart.swf?v=1710975344&amp;photo_id=4960396261&amp;photo_secret=18120df31a\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/\" media=\"video\"
+      />\n\t<size label=\"700\" width=\"\" height=\"\" source=\"https://www.flickr.com/photos/brampitoyo/4960396261/play/700/18120df31a/\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/\" media=\"video\"
+      />\n\t<size label=\"iphone_wifi\" width=\"\" height=\"\" source=\"https://www.flickr.com/photos/brampitoyo/4960396261/play/iphone_wifi/18120df31a/\"
+      url=\"https://www.flickr.com/photos/brampitoyo/4960396261/\" media=\"video\"
+      />\n</sizes>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 21 Mar 2024 12:03:39 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 a4fe4605acede182bb5c399b9c69b8c4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - cuuG-X0QijYlpKOVzy_nCAGIqQDGZo3j6txFxiFHosh67D_bZTQ3Bw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-65fc221b-14043d877f31a3cf44eb30df;Root=1-65fc221b-6af6b2061f3ec77f1c6fd87b
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.16.171
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
+      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
+      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+      />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 21 Mar 2024 12:03:40 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 a4fe4605acede182bb5c399b9c69b8c4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - X304GUsZGZZhkIEQTCzNP2_ZcJUy-7vUDBadM8uZpZMzhQ_Ig62hdg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-65fc221b-72416e830e71db0d6b61ec99;Root=1-65fc221b-39818a513f9e641624e1af07
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.3.152
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -274,6 +274,17 @@ class TestGetSinglePhoto:
 
         assert photo["location"] is None
 
+    def test_it_can_get_a_video(self, api: FlickrPhotosApi) -> None:
+        video = api.get_single_photo(photo_id="4960396261")
+
+        assert video["sizes"][-1] == {
+            "label": "iphone_wifi",
+            "width": None,
+            "height": None,
+            "source": "https://www.flickr.com/photos/brampitoyo/4960396261/play/iphone_wifi/18120df31a/",
+            "media": "video",
+        }
+
 
 class TestCollectionsPhotoResponse:
     """
@@ -354,6 +365,12 @@ class TestCollectionsPhotoResponse:
         ][0]
 
         assert photo_from_album["location"] is None
+
+    def test_can_get_collection_with_videos(self, api: FlickrPhotosApi) -> None:
+        api.get_photos_in_album(
+            user_url="https://www.flickr.com/photos/brampitoyo/",
+            album_id="72157624715342071",
+        )
 
 
 class TestGetAlbum:


### PR DESCRIPTION
Sometimes the `width`/`height` attributes are an empty string, and we throw a ValueError when `int()`-ing them. Let's fix that, it's been annoying for a while.