### PR TITLE
Return more information from the "lookup user" functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v1.9.0 - 2024-03-26
+
+*   Return more information from the `lookup_user_by_id()` and `lookup_user_by_url()` methods.
+
+    In particular, they now return a new type `UserInfo` which includes three new fields:
+    
+    - `count_photos` (int)
+    - `description` (str or None)
+    - `has_pro_account` (bool)
+
 ## v1.8.2 - 2024-03-26
 
 *   Retry errors with code 201 from the Flickr API, which usually indicates a transient issue rather than a permanent failure.

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -26,7 +26,7 @@ from .types import (
 )
 
 
-__version__ = "1.8.2"
+__version__ = "1.9.0"
 
 
 __all__ = [

--- a/src/flickr_photos_api/api.py
+++ b/src/flickr_photos_api/api.py
@@ -34,6 +34,7 @@ from .types import (
     SinglePhoto,
     Size,
     User,
+    UserInfo,
 )
 from .utils import (
     parse_date_posted,
@@ -233,7 +234,7 @@ class FlickrPhotosApi(BaseApi):
         except KeyError:
             raise LicenseNotFound(license_id=id)
 
-    def lookup_user_by_id(self, *, user_id: str) -> User:
+    def lookup_user_by_id(self, *, user_id: str) -> UserInfo:
         """
         Given the link to a user's photos or profile, return their info.
 
@@ -244,7 +245,9 @@ class FlickrPhotosApi(BaseApi):
                 "realname": "British Library",
                 "photos_url": "https://www.flickr.com/photos/britishlibrary/",
                 "profile_url": "https://www.flickr.com/people/britishlibrary/",
-                "pathalias": "britishlibrary"
+                "pathalias": "britishlibrary",
+                "description": "The British Library’s collections…",
+                "has_pro_account": True,
             }
 
         See https://www.flickr.com/services/api/flickr.people.getInfo.htm
@@ -255,6 +258,7 @@ class FlickrPhotosApi(BaseApi):
         #     <person id="12403504@N02" path_alias="britishlibrary" …>
         #   	<username>The British Library</username>
         #       <realname>British Library</realname>
+        #       <description>The British Library’s collections…</description>
         #       <photosurl>https://www.flickr.com/photos/britishlibrary/</photosurl>
         #       <profileurl>https://www.flickr.com/people/britishlibrary/</profileurl>
         #       …
@@ -269,8 +273,12 @@ class FlickrPhotosApi(BaseApi):
         username = find_required_text(person_elem, path="username")
         photos_url = find_required_text(person_elem, path="photosurl")
         profile_url = find_required_text(person_elem, path="profileurl")
+        description = find_optional_text(person_elem, path="description")
 
         path_alias = person_elem.attrib["path_alias"] or None
+
+        # This is a 0/1 boolean attribute
+        has_pro_account = person_elem.attrib["ispro"] == "1"
 
         # If the user hasn't set a realname in their profile, the element
         # will be absent from the response.
@@ -285,12 +293,14 @@ class FlickrPhotosApi(BaseApi):
             "id": user_id,
             "username": username,
             "realname": realname,
+            "description": description,
+            "has_pro_account": has_pro_account,
             "path_alias": path_alias,
             "photos_url": photos_url,
             "profile_url": profile_url,
         }
 
-    def lookup_user_by_url(self, *, url: str) -> User:
+    def lookup_user_by_url(self, *, url: str) -> UserInfo:
         """
         Given the link to a user's photos or profile, return their info.
 
@@ -301,7 +311,9 @@ class FlickrPhotosApi(BaseApi):
                 "realname": "British Library",
                 "photos_url": "https://www.flickr.com/photos/britishlibrary/",
                 "profile_url": "https://www.flickr.com/people/britishlibrary/",
-                "pathalias": "britishlibrary"
+                "pathalias": "britishlibrary",
+                "description": "The British Library’s collections…",
+                "has_pro_account": True,
             }
 
         See https://www.flickr.com/services/api/flickr.urls.lookupUser.htm
@@ -576,7 +588,14 @@ class FlickrPhotosApi(BaseApi):
                     "profile_url": f"https://www.flickr.com/people/{path_alias or owner_name}/",
                 }
             else:
-                owner = collection_owner
+                owner = {
+                    "id": collection_owner["id"],
+                    "username": collection_owner["username"],
+                    "realname": collection_owner["realname"],
+                    "path_alias": collection_owner["path_alias"],
+                    "photos_url": collection_owner["photos_url"],
+                    "profile_url": collection_owner["profile_url"],
+                }
 
             assert owner["photos_url"].endswith("/")
             url = owner["photos_url"] + photo_id + "/"
@@ -631,7 +650,16 @@ class FlickrPhotosApi(BaseApi):
         """
         Get the photos in an album.
         """
-        user = self.lookup_user_by_url(url=user_url)
+        user_info = self.lookup_user_by_url(url=user_url)
+
+        user: User = {
+            "id": user_info["id"],
+            "username": user_info["username"],
+            "realname": user_info["realname"],
+            "path_alias": user_info["path_alias"],
+            "photos_url": user_info["photos_url"],
+            "profile_url": user_info["profile_url"],
+        }
 
         # https://www.flickr.com/services/api/flickr.photosets.getPhotos.html
         resp = self.call(
@@ -804,8 +832,6 @@ class FlickrPhotosApi(BaseApi):
         This can throw a ``NotAFlickrUrl`` and ``UnrecognisedUrl`` exceptions.
         """
         parsed_url = parse_flickr_url(url)
-
-        print(parsed_url)
 
         return self.get_photos_from_parsed_flickr_url(parsed_url)
 

--- a/src/flickr_photos_api/api.py
+++ b/src/flickr_photos_api/api.py
@@ -248,6 +248,7 @@ class FlickrPhotosApi(BaseApi):
                 "pathalias": "britishlibrary",
                 "description": "The British Library’s collections…",
                 "has_pro_account": True,
+                "count_photos": 1234,
             }
 
         See https://www.flickr.com/services/api/flickr.people.getInfo.htm
@@ -259,8 +260,11 @@ class FlickrPhotosApi(BaseApi):
         #   	<username>The British Library</username>
         #       <realname>British Library</realname>
         #       <description>The British Library’s collections…</description>
-        #       <photosurl>https://www.flickr.com/photos/britishlibrary/</photosurl>
-        #       <profileurl>https://www.flickr.com/people/britishlibrary/</profileurl>
+        #       <photosurl>flickr.com/photos/britishlibrary/</photosurl>
+        #       <profileurl>flickr.com/people/britishlibrary/</profileurl>
+        #       <photos>
+        #         <count>1234</count>
+        #       </photos>
         #       …
         #     </person>
         #
@@ -276,6 +280,9 @@ class FlickrPhotosApi(BaseApi):
         description = find_optional_text(person_elem, path="description")
 
         path_alias = person_elem.attrib["path_alias"] or None
+
+        photos_elem = find_required_elem(person_elem, path="photos")
+        count_photos = int(find_required_text(photos_elem, path="count"))
 
         # This is a 0/1 boolean attribute
         has_pro_account = person_elem.attrib["ispro"] == "1"
@@ -298,6 +305,7 @@ class FlickrPhotosApi(BaseApi):
             "path_alias": path_alias,
             "photos_url": photos_url,
             "profile_url": profile_url,
+            "count_photos": count_photos,
         }
 
     def lookup_user_by_url(self, *, url: str) -> UserInfo:
@@ -314,6 +322,7 @@ class FlickrPhotosApi(BaseApi):
                 "pathalias": "britishlibrary",
                 "description": "The British Library’s collections…",
                 "has_pro_account": True,
+                "count_photos": 1234,
             }
 
         See https://www.flickr.com/services/api/flickr.urls.lookupUser.htm

--- a/src/flickr_photos_api/types.py
+++ b/src/flickr_photos_api/types.py
@@ -26,6 +26,7 @@ class User(TypedDict):
 class UserInfo(User):
     description: str | None
     has_pro_account: bool
+    count_photos: int
 
 
 # Represents the accuracy to which we know a date taken to be true.

--- a/src/flickr_photos_api/types.py
+++ b/src/flickr_photos_api/types.py
@@ -23,6 +23,11 @@ class User(TypedDict):
     profile_url: str
 
 
+class UserInfo(User):
+    description: str | None
+    has_pro_account: bool
+
+
 # Represents the accuracy to which we know a date taken to be true.
 #
 # See https://www.flickr.com/services/api/misc.dates.html

--- a/tests/fixtures/cassettes/TestLookupUser.test_description[46143783@N04-None].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_description[46143783@N04-None].yml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=46143783%40N04
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"46143783@N04\" nsid=\"46143783@N04\" ispro=\"1\" is_deleted=\"0\" iconserver=\"3804\"
+      iconfarm=\"4\" path_alias=\"\" has_stats=\"0\" pro_badge=\"standard\" expire=\"0\"
+      has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>Barra1man
+      (Busy in the Garden)</username>\n\t<realname>Barra1man (Busy in the Garden)</realname>\n\t<mbox_sha1sum>883bd71722f22dfb348ffae0fd0e1e1a918bc3e7</mbox_sha1sum>\n\t<location
+      />\n\t<timezone label=\"Pacific Time (US &amp; Canada); Tijuana\" offset=\"-08:00\"
+      timezone_id=\"PST8PDT\" timezone=\"5\" />\n\t<description />\n\t<photosurl>https://www.flickr.com/photos/46143783@N04/</photosurl>\n\t<profileurl>https://www.flickr.com/people/46143783@N04/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/46143783@N04/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2010-01-02
+      14:23:09</firstdatetaken>\n\t\t<firstdate>1262470989</firstdate>\n\t\t<count>1440</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:55:38 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 281c9390ff02ec3c7b07e745cb742ca6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - J8M3K0QZYG2-G_m7msF0J-4biXtkdU6c8aSCslSYx6u22wXNwMdNHw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a9aa-1143bbe77ac83b3f3db838b9;Root=1-6602a9aa-41d699c30776885c41278d2c
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.39.69
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_description[user_with_description].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_description[user_with_description].yml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=199258389%40N04
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"199258389@N04\" nsid=\"199258389@N04\" ispro=\"0\" is_deleted=\"0\" iconserver=\"65535\"
+      iconfarm=\"66\" path_alias=\"alexwlchan\" has_stats=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\"
+      has_free_educational_resources=\"0\">\n\t<username>alexwlchan</username>\n\t<realname>Alex
+      Chan</realname>\n\t<location />\n\t<description>Tech lead at the Flickr Foundation.</description>\n\t<photosurl>https://www.flickr.com/photos/alexwlchan/</photosurl>\n\t<profileurl>https://www.flickr.com/people/alexwlchan/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/alexwlchan/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2024-02-07
+      06:26:16</firstdatetaken>\n\t\t<firstdate>1707315985</firstdate>\n\t\t<count>1</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:57:02 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 56d50c15e83a778a8a2df6031ec29098.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - SNDEDxa70YqfzqgbvGyD0OwI4nEdoF6OXYrOBr9WNfWbIVzwTPKZQg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a9fe-19c66a6c4e619c4f3e64650e;Root=1-6602a9fe-2e1beb9b091390864ba55a3e
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.16.65
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_description[user_without_description].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_description[user_without_description].yml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=46143783%40N04
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"46143783@N04\" nsid=\"46143783@N04\" ispro=\"1\" is_deleted=\"0\" iconserver=\"3804\"
+      iconfarm=\"4\" path_alias=\"\" has_stats=\"0\" pro_badge=\"standard\" expire=\"0\"
+      has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>Barra1man
+      (Busy in the Garden)</username>\n\t<realname>Barra1man (Busy in the Garden)</realname>\n\t<mbox_sha1sum>883bd71722f22dfb348ffae0fd0e1e1a918bc3e7</mbox_sha1sum>\n\t<location
+      />\n\t<timezone label=\"Pacific Time (US &amp; Canada); Tijuana\" offset=\"-08:00\"
+      timezone_id=\"PST8PDT\" timezone=\"5\" />\n\t<description />\n\t<photosurl>https://www.flickr.com/photos/46143783@N04/</photosurl>\n\t<profileurl>https://www.flickr.com/people/46143783@N04/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/46143783@N04/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2010-01-02
+      14:23:09</firstdatetaken>\n\t\t<firstdate>1262470989</firstdate>\n\t\t<count>1440</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:57:02 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 ac0dbffb7a8577e06e873c0fe3eaab42.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _gZiufiEd3B63htY8UHNlnKfntT8P4j5rhgavspdzXuTIm-apj5jgg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a9fe-696d8dd8619d40fc2d961541;Root=1-6602a9fe-3772286a572c9ca805dd8243
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.39.10
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_has_pro_account[12403504@N02-True].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_has_pro_account[12403504@N02-True].yml
@@ -19,7 +19,7 @@ interactions:
     content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
       id=\"12403504@N02\" nsid=\"12403504@N02\" ispro=\"1\" is_deleted=\"0\" iconserver=\"65535\"
       iconfarm=\"66\" path_alias=\"britishlibrary\" has_stats=\"0\" pro_badge=\"standard\"
-      expire=\"1731948779\" has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>The
+      expire=\"2025666000\" has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>The
       British Library</username>\n\t<realname>British Library</realname>\n\t<description>Can&#039;t
       find our images? They&#039;re now listed as type &#039;illustration/art&#039;
       (not &#039;photos&#039;), so you&#039;ll need to &lt;a href=&quot;https://www.flickr.com/search/?advanced=1&amp;amp;content_types=0,2&amp;amp;video_content_types=0,1,2,3&quot;&gt;use
@@ -56,21 +56,21 @@ interactions:
       British Library is the national library of the United Kingdom and one of the
       world&#039;s greatest libraries. We hold over 14 million books, 920,000 journal
       and newspaper titles, 57 million patents, 3 million sound recordings, and much,
-      much more. &lt;/i&gt;</description>\n\t<photosurl>https://www.flickr.com/photos/britishlibrary/</photosurl>\n\t<profileurl>https://www.flickr.com/people/britishlibrary/</profileurl>\n\t<mobileurl>https://m.flickr.com/photostream.gne?id=12383156</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>1823-01-01
+      much more. &lt;/i&gt;</description>\n\t<photosurl>https://www.flickr.com/photos/britishlibrary/</photosurl>\n\t<profileurl>https://www.flickr.com/people/britishlibrary/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/britishlibrary/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>1823-01-01
       00:00:00</firstdatetaken>\n\t\t<firstdate>1385042795</firstdate>\n\t\t<count>1073589</count>\n\t</photos>\n</person>\n</rsp>\n"
     headers:
       Connection:
       - keep-alive
-      Content-Length:
-      - '1681'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Wed, 27 Dec 2023 13:35:01 GMT
+      - Tue, 26 Mar 2024 10:48:19 GMT
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 f60de1480a12e102280c50972fa2a8e8.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - 3-SUduV_-6tiuCe9pgKM7tHmzCGK3djXSkIlCY8H2IY3nH4N8HOKEQ==
+      - JnIB9HNEqiN3EkETLkUXxC4n5KY3T8AgYkrLTwvB8YEiDLxeKyhwzQ==
       X-Amz-Cf-Pop:
       - LHR5-P1
       X-Cache:
@@ -78,18 +78,15 @@ interactions:
       content-encoding:
       - gzip
       server:
-      - Apache/2.4.58 (Ubuntu)
-      set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
-        expires=Fri, 26-Jan-2024 13:35:01 GMT; Max-Age=2592000; path=/; domain=.flickr.com
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Fri, 26-Jan-2024 13:35:01 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - openresty
       vary:
       - Accept-Encoding
-      x-frame-options:
-      - SAMEORIGIN
+      x-flickr-api-request:
+      - Self=1-6602a7f3-141e7e781fde0af61ec28e57;Root=1-6602a7f3-182d430d17c9b01a6c176508
       x-robots-tag:
       - noindex
+      x-server:
+      - serverless-proxy-10.78.19.152
     http_version: HTTP/1.1
     status_code: 200
 version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_has_pro_account[199258389@N04-False].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_has_pro_account[199258389@N04-False].yml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=199258389%40N04
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"199258389@N04\" nsid=\"199258389@N04\" ispro=\"0\" is_deleted=\"0\" iconserver=\"65535\"
+      iconfarm=\"66\" path_alias=\"alexwlchan\" has_stats=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\"
+      has_free_educational_resources=\"0\">\n\t<username>alexwlchan</username>\n\t<realname>Alex
+      Chan</realname>\n\t<location />\n\t<description>Tech lead at the Flickr Foundation.</description>\n\t<photosurl>https://www.flickr.com/photos/alexwlchan/</photosurl>\n\t<profileurl>https://www.flickr.com/people/alexwlchan/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/alexwlchan/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2024-02-07
+      06:26:16</firstdatetaken>\n\t\t<firstdate>1707315985</firstdate>\n\t\t<count>1</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:48:19 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 37e34b9c40877c3dfcda3d91f889e98e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - oxiXQyNgFnosvi4dlRIu0rAXgYo4FPo_oLxF8oky6SsfQLmZ5I-vXw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a7f3-220b5ab65526f1e604e1c201;Root=1-6602a7f3-433b0190653cfce25da796c5
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.32.246
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_id.yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_id.yml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=199258389%40N04
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"199258389@N04\" nsid=\"199258389@N04\" ispro=\"0\" is_deleted=\"0\" iconserver=\"65535\"
+      iconfarm=\"66\" path_alias=\"alexwlchan\" has_stats=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\"
+      has_free_educational_resources=\"0\">\n\t<username>alexwlchan</username>\n\t<realname>Alex
+      Chan</realname>\n\t<location />\n\t<description>Tech lead at the Flickr Foundation.</description>\n\t<photosurl>https://www.flickr.com/photos/alexwlchan/</photosurl>\n\t<profileurl>https://www.flickr.com/people/alexwlchan/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/alexwlchan/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2024-02-07
+      06:26:16</firstdatetaken>\n\t\t<firstdate>1707315985</firstdate>\n\t\t<count>1</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:48:18 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 718d744faad6ff02c7a7ca517a01865a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - XGtPCZ6EsWe_baJ7aT5Cadcrrkcl1ZMJTy9HEggClT69dcgQFU4PDw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a7f2-55c14ca1144a0fcc2dfc0594;Root=1-6602a7f2-1bc9bbb93731ea5c6d9149ab
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.19.152
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url.yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url.yml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupUser&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2F199246608%40N02
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<user
+      id=\"199246608@N02\">\n\t<username>cefarrjf87</username>\n</user>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:55:37 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 063bfb014e66ef670fc62ff044660cf2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - NFFntvouzlh2ToWM0XqFPugdELuRM06k1MlXQz2cLv6AqI_NwhljXw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a9a9-5645461874937abf0d3acb48;Root=1-6602a9a9-4498f4804d186612154f62fe
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.10.17
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=199246608%40N02
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"199246608@N02\" nsid=\"199246608@N02\" ispro=\"0\" is_deleted=\"0\" iconserver=\"0\"
+      iconfarm=\"0\" path_alias=\"\" has_stats=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\"
+      has_free_educational_resources=\"0\">\n\t<username>cefarrjf87</username>\n\t<realname>Alex
+      Chan</realname>\n\t<location />\n\t<description />\n\t<photosurl>https://www.flickr.com/photos/199246608@N02/</photosurl>\n\t<profileurl>https://www.flickr.com/people/199246608@N02/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/199246608@N02/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2014-09-18
+      14:11:54</firstdatetaken>\n\t\t<firstdate>1696938538</firstdate>\n\t\t<count>38</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:55:37 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 063bfb014e66ef670fc62ff044660cf2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dXYe5ThTBH_BGhOMNLgd_Bq4rl6e3dbJ25uvrEYrT7QigVTDR90Vmw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a9a9-62e8f8c408d98ec915ad1cf4;Root=1-6602a9a9-132fe20f3a6883730f63e9ea
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.16.171
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url[199246608@N02].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url[199246608@N02].yml
@@ -21,35 +21,32 @@ interactions:
     headers:
       Connection:
       - keep-alive
-      Content-Length:
-      - '129'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Sun, 05 Nov 2023 13:52:55 GMT
+      - Tue, 26 Mar 2024 10:49:59 GMT
+      Transfer-Encoding:
+      - chunked
       Via:
-      - 1.1 829762c3f42db9d1ea41f24010e3ac9e.cloudfront.net (CloudFront)
+      - 1.1 1fca0a05bafb02d090ba78d3ff7b5b4c.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - fqogoei3MqdEEB2PRuPJlvwrsxsl5iePRDNZJWqozmigIWWN88lpSg==
+      - MFG1o3j1LzZuiKl3uIK-EzQW9335ld9mNcCn-0hA8PTOZDONfxCYeg==
       X-Amz-Cf-Pop:
-      - LHR50-P8
+      - LHR5-P1
       X-Cache:
       - Miss from cloudfront
       content-encoding:
       - gzip
       server:
-      - Apache/2.4.57 (Ubuntu)
-      set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
-        expires=Tue, 05-Dec-2023 13:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Tue, 05-Dec-2023 13:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - openresty
       vary:
       - Accept-Encoding
-      x-frame-options:
-      - SAMEORIGIN
+      x-flickr-api-request:
+      - Self=1-6602a857-1ac2f7ef32cfd1ee0feb16fa;Root=1-6602a857-71eb41546f3512cc5cdc91aa
       x-robots-tag:
       - noindex
+      x-server:
+      - serverless-proxy-10.78.12.122
     http_version: HTTP/1.1
     status_code: 200
 - request:
@@ -61,8 +58,6 @@ interactions:
       - gzip, deflate
       connection:
       - keep-alive
-      cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
       host:
       - api.flickr.com
       user-agent:
@@ -75,38 +70,37 @@ interactions:
       id=\"199246608@N02\" nsid=\"199246608@N02\" ispro=\"0\" is_deleted=\"0\" iconserver=\"0\"
       iconfarm=\"0\" path_alias=\"\" has_stats=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\"
       has_free_educational_resources=\"0\">\n\t<username>cefarrjf87</username>\n\t<realname>Alex
-      Chan</realname>\n\t<location />\n\t<description />\n\t<photosurl>https://www.flickr.com/photos/199246608@N02/</photosurl>\n\t<profileurl>https://www.flickr.com/people/199246608@N02/</profileurl>\n\t<mobileurl>https://m.flickr.com/photostream.gne?id=199226260</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2023-05-12
-      14:12:01</firstdatetaken>\n\t\t<firstdate>1696938538</firstdate>\n\t\t<count>16</count>\n\t</photos>\n</person>\n</rsp>\n"
+      Chan</realname>\n\t<location />\n\t<description />\n\t<photosurl>https://www.flickr.com/photos/199246608@N02/</photosurl>\n\t<profileurl>https://www.flickr.com/people/199246608@N02/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/199246608@N02/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2014-09-18
+      14:11:54</firstdatetaken>\n\t\t<firstdate>1696938538</firstdate>\n\t\t<count>38</count>\n\t</photos>\n</person>\n</rsp>\n"
     headers:
       Connection:
       - keep-alive
-      Content-Length:
-      - '388'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Sun, 05 Nov 2023 13:52:55 GMT
+      - Tue, 26 Mar 2024 10:49:59 GMT
+      Transfer-Encoding:
+      - chunked
       Via:
-      - 1.1 829762c3f42db9d1ea41f24010e3ac9e.cloudfront.net (CloudFront)
+      - 1.1 1fca0a05bafb02d090ba78d3ff7b5b4c.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - jqkoUtCpV2NxcG6DWe26ENDA60cI8g3brr6uPunCcEeUqrN7Z039MQ==
+      - YApOs-Q4Irhh8nuUBiFW-2iXx9Y4svKjmJJPLFnoyo4SICncYCFflw==
       X-Amz-Cf-Pop:
-      - LHR50-P8
+      - LHR5-P1
       X-Cache:
       - Miss from cloudfront
       content-encoding:
       - gzip
       server:
-      - Apache/2.4.57 (Ubuntu)
-      set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Tue, 05-Dec-2023 13:52:55 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - openresty
       vary:
       - Accept-Encoding
-      x-frame-options:
-      - SAMEORIGIN
+      x-flickr-api-request:
+      - Self=1-6602a857-4a1195df3fbdead222f50790;Root=1-6602a857-0ac0b09720d6589164b90ccd
       x-robots-tag:
       - noindex
+      x-server:
+      - serverless-proxy-10.78.10.17
     http_version: HTTP/1.1
     status_code: 200
 version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url[britishlibrary].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url[britishlibrary].yml
@@ -21,35 +21,32 @@ interactions:
     headers:
       Connection:
       - keep-alive
-      Content-Length:
-      - '137'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Sun, 05 Nov 2023 13:52:54 GMT
+      - Tue, 26 Mar 2024 10:49:59 GMT
+      Transfer-Encoding:
+      - chunked
       Via:
-      - 1.1 2a9e6bac3f98da321b499bb32df92550.cloudfront.net (CloudFront)
+      - 1.1 b1e5e18d3663c842a7617d7893ff405e.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - xRGpp3uPhhRvcaMlXhEcMW4s3XV8x1TdbzU96QZprijmT7PIpZs85Q==
+      - dFOVfU6dhSOZ_OVXXjVrbZxLPHjHLKlJgZiqYsLb8j0rzlDxn12z9A==
       X-Amz-Cf-Pop:
-      - LHR50-P8
+      - LHR5-P1
       X-Cache:
       - Miss from cloudfront
       content-encoding:
       - gzip
       server:
-      - Apache/2.4.57 (Ubuntu)
-      set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
-        expires=Tue, 05-Dec-2023 13:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Tue, 05-Dec-2023 13:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - openresty
       vary:
       - Accept-Encoding
-      x-frame-options:
-      - SAMEORIGIN
+      x-flickr-api-request:
+      - Self=1-6602a856-6b176d9f1fff830f79fb460d;Root=1-6602a856-164b62fa3ab2f4880cb0b80c
       x-robots-tag:
       - noindex
+      x-server:
+      - serverless-proxy-10.78.16.171
     http_version: HTTP/1.1
     status_code: 200
 - request:
@@ -61,8 +58,6 @@ interactions:
       - gzip, deflate
       connection:
       - keep-alive
-      cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
       host:
       - api.flickr.com
       user-agent:
@@ -74,7 +69,7 @@ interactions:
     content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
       id=\"12403504@N02\" nsid=\"12403504@N02\" ispro=\"1\" is_deleted=\"0\" iconserver=\"65535\"
       iconfarm=\"66\" path_alias=\"britishlibrary\" has_stats=\"0\" pro_badge=\"standard\"
-      expire=\"1731948779\" has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>The
+      expire=\"2025666000\" has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>The
       British Library</username>\n\t<realname>British Library</realname>\n\t<description>Can&#039;t
       find our images? They&#039;re now listed as type &#039;illustration/art&#039;
       (not &#039;photos&#039;), so you&#039;ll need to &lt;a href=&quot;https://www.flickr.com/search/?advanced=1&amp;amp;content_types=0,2&amp;amp;video_content_types=0,1,2,3&quot;&gt;use
@@ -111,38 +106,37 @@ interactions:
       British Library is the national library of the United Kingdom and one of the
       world&#039;s greatest libraries. We hold over 14 million books, 920,000 journal
       and newspaper titles, 57 million patents, 3 million sound recordings, and much,
-      much more. &lt;/i&gt;</description>\n\t<photosurl>https://www.flickr.com/photos/britishlibrary/</photosurl>\n\t<profileurl>https://www.flickr.com/people/britishlibrary/</profileurl>\n\t<mobileurl>https://m.flickr.com/photostream.gne?id=12383156</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>1823-01-01
+      much more. &lt;/i&gt;</description>\n\t<photosurl>https://www.flickr.com/photos/britishlibrary/</photosurl>\n\t<profileurl>https://www.flickr.com/people/britishlibrary/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/britishlibrary/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>1823-01-01
       00:00:00</firstdatetaken>\n\t\t<firstdate>1385042795</firstdate>\n\t\t<count>1073589</count>\n\t</photos>\n</person>\n</rsp>\n"
     headers:
       Connection:
       - keep-alive
-      Content-Length:
-      - '1681'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Sun, 05 Nov 2023 13:52:54 GMT
+      - Tue, 26 Mar 2024 10:49:59 GMT
+      Transfer-Encoding:
+      - chunked
       Via:
-      - 1.1 2a9e6bac3f98da321b499bb32df92550.cloudfront.net (CloudFront)
+      - 1.1 b1e5e18d3663c842a7617d7893ff405e.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - CClzC85sxD5AaqotQNrAvTkAis_JRMAjvYwcbwY3XWuVANGGmGJgAA==
+      - 1nS5eHN5ZKDkGAHXB6eCwPwwI9PX6gGNwfQB7zNqo1zvimm-J4INfw==
       X-Amz-Cf-Pop:
-      - LHR50-P8
+      - LHR5-P1
       X-Cache:
       - Miss from cloudfront
       content-encoding:
       - gzip
       server:
-      - Apache/2.4.57 (Ubuntu)
-      set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Tue, 05-Dec-2023 13:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - openresty
       vary:
       - Accept-Encoding
-      x-frame-options:
-      - SAMEORIGIN
+      x-flickr-api-request:
+      - Self=1-6602a857-4685213e08987a1a1a47030d;Root=1-6602a857-232f24363be8ba430c0486c8
       x-robots-tag:
       - noindex
+      x-server:
+      - serverless-proxy-10.78.10.17
     http_version: HTTP/1.1
     status_code: 200
 version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url[obamawhitehouse].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url[obamawhitehouse].yml
@@ -21,35 +21,32 @@ interactions:
     headers:
       Connection:
       - keep-alive
-      Content-Length:
-      - '143'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Sun, 05 Nov 2023 13:52:54 GMT
+      - Tue, 26 Mar 2024 10:49:58 GMT
+      Transfer-Encoding:
+      - chunked
       Via:
-      - 1.1 88e066f06ce21d9d589e0b7dba0cd180.cloudfront.net (CloudFront)
+      - 1.1 f9f510ca7ffa469320fb8f68f90942f4.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - V9z16GIUJIK5cA9Kl4c5hY5t-4AzQqLksB0-K3S3YmE0PEFM_v3ZQw==
+      - R5Gwb5kvbnyZpV0ModGtiGbF9ZDozzATR4_oom_aZ92xtLBlNqjG7g==
       X-Amz-Cf-Pop:
-      - LHR50-P8
+      - LHR5-P1
       X-Cache:
       - Miss from cloudfront
       content-encoding:
       - gzip
       server:
-      - Apache/2.4.57 (Ubuntu)
-      set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
-        expires=Tue, 05-Dec-2023 13:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Tue, 05-Dec-2023 13:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - openresty
       vary:
       - Accept-Encoding
-      x-frame-options:
-      - SAMEORIGIN
+      x-flickr-api-request:
+      - Self=1-6602a856-7e6b5ee27285aa3d732474ea;Root=1-6602a856-1cdde1056a65ada46c778850
       x-robots-tag:
       - noindex
+      x-server:
+      - serverless-proxy-10.78.16.171
     http_version: HTTP/1.1
     status_code: 200
 - request:
@@ -61,8 +58,6 @@ interactions:
       - gzip, deflate
       connection:
       - keep-alive
-      cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
       host:
       - api.flickr.com
       user-agent:
@@ -79,38 +74,37 @@ interactions:
       label=\"Eastern Time (US &amp; Canada)\" offset=\"-05:00\" timezone_id=\"EST5EDT\"
       timezone=\"14\" />\n\t<description>This account will be maintained by the National
       Archives and Records Administration (NARA) and will serve as an archive of Obama
-      Administration content.</description>\n\t<photosurl>https://www.flickr.com/photos/obamawhitehouse/</photosurl>\n\t<profileurl>https://www.flickr.com/people/obamawhitehouse/</profileurl>\n\t<mobileurl>https://m.flickr.com/photostream.gne?id=35568324</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2005-06-12
+      Administration content.</description>\n\t<photosurl>https://www.flickr.com/photos/obamawhitehouse/</photosurl>\n\t<profileurl>https://www.flickr.com/people/obamawhitehouse/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/obamawhitehouse/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2005-06-12
       01:25:15</firstdatetaken>\n\t\t<firstdate>1240962741</firstdate>\n\t\t<count>6668</count>\n\t</photos>\n</person>\n</rsp>\n"
     headers:
       Connection:
       - keep-alive
-      Content-Length:
-      - '588'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Sun, 05 Nov 2023 13:52:54 GMT
+      - Tue, 26 Mar 2024 10:49:58 GMT
+      Transfer-Encoding:
+      - chunked
       Via:
-      - 1.1 88e066f06ce21d9d589e0b7dba0cd180.cloudfront.net (CloudFront)
+      - 1.1 f9f510ca7ffa469320fb8f68f90942f4.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - QXZmAO7ZTQ8HVWXx2UAPzLH2W7pug4T4lJKMr7ar34I8BWrjuT1UZg==
+      - s70CZOTzDJdQoB1sJDj4XwFtU0aN1XhL6tksmRs_I1xCCPyvNi_ytg==
       X-Amz-Cf-Pop:
-      - LHR50-P8
+      - LHR5-P1
       X-Cache:
       - Miss from cloudfront
       content-encoding:
       - gzip
       server:
-      - Apache/2.4.57 (Ubuntu)
-      set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Tue, 05-Dec-2023 13:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - openresty
       vary:
       - Accept-Encoding
-      x-frame-options:
-      - SAMEORIGIN
+      x-flickr-api-request:
+      - Self=1-6602a856-03a1bf6c54658bcc64c16e3b;Root=1-6602a856-3c3cc05426acd6715d2a6fe4
       x-robots-tag:
       - noindex
+      x-server:
+      - serverless-proxy-10.78.12.122
     http_version: HTTP/1.1
     status_code: 200
 version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url_doesnt_use_username.yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_lookup_user_by_url_doesnt_use_username.yml
@@ -1,0 +1,142 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupUser&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fbritishlibrary%2F
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<user
+      id=\"12403504@N02\">\n\t<username>The British Library</username>\n</user>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:55:37 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 cebcb0d17c62ea30e361587bfe114ca0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - TdrixgZ7_IhigNpNECX_k3VjYSBIsxopPR1reO2qAoun1J26i33x4w==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a9a9-17443d383b22fc2e5f461797;Root=1-6602a9a9-570be90c2bc8f81503ad9747
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.16.171
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=12403504%40N02
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"12403504@N02\" nsid=\"12403504@N02\" ispro=\"1\" is_deleted=\"0\" iconserver=\"65535\"
+      iconfarm=\"66\" path_alias=\"britishlibrary\" has_stats=\"0\" pro_badge=\"standard\"
+      expire=\"2025666000\" has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>The
+      British Library</username>\n\t<realname>British Library</realname>\n\t<description>Can&#039;t
+      find our images? They&#039;re now listed as type &#039;illustration/art&#039;
+      (not &#039;photos&#039;), so you&#039;ll need to &lt;a href=&quot;https://www.flickr.com/search/?advanced=1&amp;amp;content_types=0,2&amp;amp;video_content_types=0,1,2,3&quot;&gt;use
+      Advanced Search to find our images&lt;/a&gt;. Find out how to &#039;&lt;a href=&quot;https://www.flickrhelp.com/hc/en-us/articles/19964841478036&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;Search by Content Type&lt;/a&gt;&#039;
+      and &#039;&lt;a href=&quot;https://www.flickrhelp.com/hc/en-us/articles/4404381838100&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;Using Advanced Search&lt;/a&gt;&#039;.\n\n--\nThe
+      British Library\u2019s collections on Flickr Commons offer access to millions
+      of public domain images, which we encourage you to explore and &lt;a href=&quot;https://www.bl.uk/about-us/terms-and-conditions/content-on-flickr-and-wikimedia-commons&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;re-use&lt;/a&gt;. The &lt;a href=&quot;https://www.bl.uk/about-us/terms-and-conditions/content-on-flickr-and-wikimedia-commons&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;release of these collections into the
+      public domain&lt;/a&gt; represent the Library&#039;s desire to improve knowledge
+      of and about them, to enable novel and unexpected ways of using them, and to
+      begin working with researchers to explore and interpret large scale digital
+      collections.\n\nPublic Domain Mark and CC0 images from British Library collections
+      are being made available to increase access and encourage reuse of our open
+      materials. These works are marked \u201Cno known copyright restrictions\u201D,
+      indicating that the British Library is unaware of any current copyright restrictions
+      on these works. Please see our &lt;a href=&quot;https://www.bl.uk/help/ethical-terms-of-use&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;ethical terms of use&lt;/a&gt; statement
+      for culturally sensitive images.\n\nThe &lt;a href=&quot;http://britishlibrary.typepad.co.uk/digital-scholarship/2013/12/a-million-first-steps.html&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;first set&lt;/a&gt; we have added come
+      from a &lt;a href=&quot;http://labs.bl.uk/&quot; rel=&quot;noreferrer nofollow&quot;&gt;British
+      Library Labs&lt;/a&gt; project dubbed the &lt;a href=&quot;http://mechanicalcurator.tumblr.com&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;Mechanical Curator&lt;/a&gt;, which located
+      more than a million images from within our digitised collection of over 65,000
+      books from the 17th, 18th and 19th centuries. \n\nThis account is managed by
+      the British Library Digital Research Team. You can follow us on Mastodon &lt;a
+      href=&quot;https://techhub.social/@BL_DigiSchol&quot; rel=&quot;noreferrer nofollow&quot;&gt;@BL_DigiSchol@techhub.social
+      &lt;/a&gt; or Bluesky &lt;a href=&quot;https://bsky.app/profile/bldigischol.bsky.social&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;@bldigischol.bsky.social&lt;/a&gt;, or
+      get in touch by emailing &lt;a href=&quot;mailto:digitalresearch@bl.uk&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;digitalresearch@bl.uk&lt;/a&gt;.\n\n&lt;i&gt;The
+      British Library is the national library of the United Kingdom and one of the
+      world&#039;s greatest libraries. We hold over 14 million books, 920,000 journal
+      and newspaper titles, 57 million patents, 3 million sound recordings, and much,
+      much more. &lt;/i&gt;</description>\n\t<photosurl>https://www.flickr.com/photos/britishlibrary/</photosurl>\n\t<profileurl>https://www.flickr.com/people/britishlibrary/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/britishlibrary/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>1823-01-01
+      00:00:00</firstdatetaken>\n\t\t<firstdate>1385042795</firstdate>\n\t\t<count>1073589</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:55:38 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 cebcb0d17c62ea30e361587bfe114ca0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - xLz3qw8xM72Go7BSPb_fhkskIy9mTk42Fk9XpD3i6cy1K8kdWa7VFQ==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a9a9-014a44e3582dc31b2588d906;Root=1-6602a9a9-69e549f174b1aeb63a27f9a3
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.32.246
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_realname[199258389@N04-Alex Chan].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_realname[199258389@N04-Alex Chan].yml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=199258389%40N04
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"199258389@N04\" nsid=\"199258389@N04\" ispro=\"0\" is_deleted=\"0\" iconserver=\"65535\"
+      iconfarm=\"66\" path_alias=\"alexwlchan\" has_stats=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\"
+      has_free_educational_resources=\"0\">\n\t<username>alexwlchan</username>\n\t<realname>Alex
+      Chan</realname>\n\t<location />\n\t<description>Tech lead at the Flickr Foundation.</description>\n\t<photosurl>https://www.flickr.com/photos/alexwlchan/</photosurl>\n\t<profileurl>https://www.flickr.com/people/alexwlchan/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/alexwlchan/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2024-02-07
+      06:26:16</firstdatetaken>\n\t\t<firstdate>1707315985</firstdate>\n\t\t<count>1</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:54:06 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 37e34b9c40877c3dfcda3d91f889e98e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - afy9tLn5gDeuixu2-kGDzsOjYeFsN2YLaXTWJxXdO-DJWrAx98nJVg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a94e-0ea2614b7a3a4a7e5b376702;Root=1-6602a94e-493273fb330e72506b2cc0e2
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.32.246
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestLookupUser.test_realname[35591378@N03-None].yml
+++ b/tests/fixtures/cassettes/TestLookupUser.test_realname[35591378@N03-None].yml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=35591378%40N03
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"35591378@N03\" nsid=\"35591378@N03\" ispro=\"1\" is_deleted=\"0\" iconserver=\"475\"
+      iconfarm=\"1\" path_alias=\"obamawhitehouse\" has_stats=\"0\" pro_badge=\"standard\"
+      expire=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>Obama
+      White House Archived</username>\n\t<location>Washington, DC</location>\n\t<timezone
+      label=\"Eastern Time (US &amp; Canada)\" offset=\"-05:00\" timezone_id=\"EST5EDT\"
+      timezone=\"14\" />\n\t<description>This account will be maintained by the National
+      Archives and Records Administration (NARA) and will serve as an archive of Obama
+      Administration content.</description>\n\t<photosurl>https://www.flickr.com/photos/obamawhitehouse/</photosurl>\n\t<profileurl>https://www.flickr.com/people/obamawhitehouse/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/obamawhitehouse/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2005-06-12
+      01:25:15</firstdatetaken>\n\t\t<firstdate>1240962741</firstdate>\n\t\t<count>6668</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:54:07 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 454abb506de84114b90eb4ff9b2798f6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - BkiDlE1lU22AV2x46KBqcKiEGfEHxBFH3vSNONP6JXIdJ0xkaIFnUw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a94f-541cf270384bf7f7574b6274;Root=1-6602a94f-7890698d39e50db35ee29cdb
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.39.10
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/test_empty_description_is_none.yml
+++ b/tests/fixtures/cassettes/test_empty_description_is_none.yml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=46143783%40N04
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"46143783@N04\" nsid=\"46143783@N04\" ispro=\"1\" is_deleted=\"0\" iconserver=\"3804\"
+      iconfarm=\"4\" path_alias=\"\" has_stats=\"0\" pro_badge=\"standard\" expire=\"0\"
+      has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>Barra1man
+      (Busy in the Garden)</username>\n\t<realname>Barra1man (Busy in the Garden)</realname>\n\t<mbox_sha1sum>883bd71722f22dfb348ffae0fd0e1e1a918bc3e7</mbox_sha1sum>\n\t<location
+      />\n\t<timezone label=\"Pacific Time (US &amp; Canada); Tijuana\" offset=\"-08:00\"
+      timezone_id=\"PST8PDT\" timezone=\"5\" />\n\t<description />\n\t<photosurl>https://www.flickr.com/photos/46143783@N04/</photosurl>\n\t<profileurl>https://www.flickr.com/people/46143783@N04/</profileurl>\n\t<mobileurl>https://www.flickr.com/photos/46143783@N04/</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2010-01-02
+      14:23:09</firstdatetaken>\n\t\t<firstdate>1262470989</firstdate>\n\t\t<count>1440</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 26 Mar 2024 10:44:58 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 081e5088637a101207bef39b8d7f3d4c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - xS-jkE32g20FExk2Wzbf8MHgaZ5QHNMieFy_8bbc1gCdDIlpcCzRDw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6602a72a-15aaa6f910bf3bcb08bd2b63;Root=1-6602a72a-05b4bf5b495f03af47ec31c6
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.12.116
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,6 +109,7 @@ class TestLookupUser:
             "path_alias": None,
             "photos_url": "https://www.flickr.com/photos/199246608@N02/",
             "profile_url": "https://www.flickr.com/people/199246608@N02/",
+            "count_photos": 38,
         }
 
     def test_lookup_user_by_url_doesnt_use_username(self, api: FlickrPhotosApi) -> None:
@@ -133,6 +134,7 @@ class TestLookupUser:
             "profile_url": "https://www.flickr.com/people/alexwlchan/",
             "description": "Tech lead at the Flickr Foundation.",
             "has_pro_account": False,
+            "count_photos": 1,
         }
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This means we can get more information returned from these API calls, and save calling the API twice to get info that is/isn't exposed via Python.

This is part of https://github.com/Flickr-Foundation/commons.flickr.org/issues/108