### PR TITLE
Add a new method that wraps the `flickr.photos.getInfo` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.12.0 - 2024-04-29
+
+*   Add a new method `get_single_photo_info()` which wraps all the information returned by the `flickr.photos.getInfo` API.
+
 ## v1.11.0 - 2024-04-23
 
 *   Refactor the internals to expose a couple of new methods for getting a single page or a continuous stream of photos.

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -25,10 +25,11 @@ from .types import (
     AlbumInfo,
     GalleryInfo,
     GroupInfo,
+    SinglePhotoInfo,
 )
 
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 
 __all__ = [
@@ -48,6 +49,7 @@ __all__ = [
     "Size",
     "SafetyLevel",
     "SinglePhoto",
+    "SinglePhotoInfo",
     "CollectionOfPhotos",
     "PhotosFromUrl",
     "PhotosInAlbum",

--- a/src/flickr_photos_api/types.py
+++ b/src/flickr_photos_api/types.py
@@ -1,4 +1,5 @@
 import datetime
+import typing
 from typing import Literal, TypedDict
 from xml.etree import ElementTree as ET
 
@@ -67,6 +68,38 @@ class Comment(TypedDict):
 #
 # https://www.flickrhelp.com/hc/en-us/articles/4404064206996-Content-filters#h_01HBRRKK6F4ZAW6FTWV8BPA2G7
 SafetyLevel = Literal["safe", "moderate", "restricted"]
+
+
+class SinglePhotoInfo(typing.TypedDict):
+    """
+    Represents a response from the flickr.photos.getInfo API.
+    """
+
+    id: str
+
+    secret: str
+    server: str
+    farm: str
+    original_format: str | None
+
+    owner: User
+
+    safety_level: SafetyLevel
+
+    license: License
+
+    title: str | None
+    description: str | None
+    tags: list[str]
+
+    date_posted: datetime.datetime
+    date_taken: DateTaken | None
+    location: LocationInfo | None
+
+    count_comments: int
+    count_views: int
+
+    photo_page_url: str
 
 
 class SinglePhoto(TypedDict):


### PR DESCRIPTION
This is part of the general refactoring to make this library more a collection of generic pieces you can put together, and have less of its own opinions.