### PR TITLE
Tidy up the exceptions for deleted users + unrecognised error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v2.0.1 - 2024-04-30
+
+This slightly refines the list of available exceptions:
+
+-   The `lookup_user_by_id()` and `lookup_user_by_url()` methods can now throw a new `UserDeleted` exception if you try to look up a Flickr user who's deleted their account.
+-   An error with an unrecognised code will now throw `UnrecognisedFlickrApiException` instead of `FlickrApiException`.
+    This should make it easier to distinguish and handle unrecognised errors.
+
 ## v2.0.0 - 2024-04-30
 
 This is a fairly major internal refactor to make the library easier to work on.

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -5,6 +5,8 @@ from .exceptions import (
     InvalidXmlException,
     ResourceNotFound,
     LicenseNotFound,
+    UnrecognisedFlickrApiException,
+    UserDeleted,
 )
 from .types import (
     Comment,
@@ -29,7 +31,7 @@ from .types import (
 )
 
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 
 __all__ = [
@@ -58,5 +60,7 @@ __all__ = [
     "AlbumInfo",
     "GalleryInfo",
     "GroupInfo",
+    "UnrecognisedFlickrApiException",
+    "UserDeleted",
     "__version__",
 ]

--- a/src/flickr_photos_api/exceptions.py
+++ b/src/flickr_photos_api/exceptions.py
@@ -9,6 +9,14 @@ class FlickrApiException(Exception):
     pass
 
 
+class UnrecognisedFlickrApiException(FlickrApiException):
+    """
+    Thrown when we get an unrecognised error from the Flickr API.
+    """
+
+    pass
+
+
 class InvalidXmlException(FlickrApiException):
     """
     Thrown when we get invalid XML from the Flickr API.
@@ -46,10 +54,16 @@ class ResourceNotFound(FlickrApiException):
     Thrown when you try to look up a resource that doesn't exist.
     """
 
-    def __init__(self, method: str, params: dict[str, str] | None):
-        super().__init__(
-            f"Unable to find resource at {method} with properties {params}"
-        )
+    pass
+
+
+class UserDeleted(ResourceNotFound):
+    """
+    Thrown when you try to look up a user who's deleted their account.
+    """
+
+    def __init__(self, user_id: str):
+        super().__init__(f"User is deleted: {user_id!r}")
 
 
 class LicenseNotFound(FlickrApiException):

--- a/tests/fixtures/cassettes/TestLookupUserById.test_lookup_deleted_user.yml
+++ b/tests/fixtures/cassettes/TestLookupUserById.test_lookup_deleted_user.yml
@@ -1,0 +1,57 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=51979177%40N02
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"fail\">\n\t<err
+      code=\"5\" msg=\"User deleted\" />\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 30 Apr 2024 12:12:15 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 9e4ef84d8626e7ec2ca2411a9eeb43c4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - AZ2Ad1lNbMSzamcnSOhPLKXkiG0hwhGnVmTN4WSTLHdXb0OQYQ1Kaw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Thu, 30-May-2024 12:12:15 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 30-May-2024 12:12:15 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6630e01f-37b01187678fa62f0166c65c;Root=1-6630e01f-4bc002b153d977345d686828
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.4.5
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestLookupUserByUrl.test_lookup_deleted_user.yml
+++ b/tests/fixtures/cassettes/TestLookupUserByUrl.test_lookup_deleted_user.yml
@@ -1,0 +1,57 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=51979177%40N02
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"fail\">\n\t<err
+      code=\"5\" msg=\"User deleted\" />\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 30 Apr 2024 12:12:15 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 d67d31689e6e1651260ad9b2311bb686.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Npmxx7o8eI8mrIUzp1vnvRiitENLLMAAO-tf5OiaAdcdh6snfnkfWA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Thu, 30-May-2024 12:12:15 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 30-May-2024 12:12:15 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6630e01f-78568af97496e0a7604f7a67;Root=1-6630e01f-467cfbcd02fbf30e7530a356
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.32.246
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1


### PR DESCRIPTION
This is because I'm seeing error code `5` (user deleted) when I try to deploy the new library in the Commons Explorer.

This is part of #42.