### PR TITLE
Fix a bug with missing realname in user photostreams

### DIFF
--- a/src/flickr_photos_api/api/collection_methods.py
+++ b/src/flickr_photos_api/api/collection_methods.py
@@ -309,7 +309,7 @@ class CollectionMethods(LicenseMethods, UserMethods):
         owner = create_user(
             id=first_photo.attrib["owner"],
             username=first_photo.attrib["ownername"],
-            realname=first_photo.attrib["realname"],
+            realname=first_photo.attrib.get("realname"),
             path_alias=first_photo.attrib["pathalias"],
         )
 

--- a/tests/api/test_collection_methods.py
+++ b/tests/api/test_collection_methods.py
@@ -251,6 +251,22 @@ class TestGetPhotosInUserPhotostream:
 
         assert photos == {"count_pages": 1, "count_photos": 0, "photos": []}
 
+    def test_no_realname_is_none(self, api: FlickrApi) -> None:
+        # This is the Commons Test account, which doesn't have
+        # a 'realname' set
+        result = api.get_photos_in_user_photostream(user_id="200049760@N08")
+
+        owner = result["photos"][0]["owner"]
+        assert owner["realname"] is None
+
+    def test_no_path_alias_is_none(self, api: FlickrApi) -> None:
+        # This is the Commons Test account, which doesn't have
+        # a 'path_alias' set
+        result = api.get_photos_in_user_photostream(user_id="200049760@N08")
+
+        owner = result["photos"][0]["owner"]
+        assert owner["path_alias"] is None
+
 
 def test_get_photos_in_group_pool(api: FlickrApi) -> None:
     photos = api.get_photos_in_group_pool(

--- a/tests/fixtures/cassettes/TestGetPhotosInUserPhotostream.test_no_path_alias_is_none.yml
+++ b/tests/fixtures/cassettes/TestGetPhotosInUserPhotostream.test_no_path_alias_is_none.yml
@@ -1,0 +1,229 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Coriginal_format%2Cowner_name%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o%2Ctags%2Cgeo%2Curl_q%2Curl_l%2Cdescription%2Csafety_level%2Crealname%2Cpath_alias%2Ccount_comments%2Ccount_views&method=flickr.people.getPublicPhotos&page=1&per_page=10&user_id=200049760%40N08
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photos
+      page=\"1\" pages=\"1\" perpage=\"10\" total=\"7\">\n\t<photo id=\"53619326403\"
+      owner=\"200049760@N08\" secret=\"3bc8ef2f43\" server=\"65535\" farm=\"66\" title=\"wet
+      poppy\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"7\" safety_level=\"0\"
+      dateupload=\"1711743634\" datetaken=\"2024-03-29 16:19:22\" datetakengranularity=\"0\"
+      datetakenunknown=\"1\" ownername=\"CommonsTestAccount\" count_views=\"93\" count_comments=\"0\"
+      tags=\"\" originalsecret=\"f281b12ff8\" originalformat=\"jpg\" latitude=\"0\"
+      longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_t.jpg\"
+      height_t=\"61\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_m.jpg\"
+      height_s=\"148\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43.jpg\"
+      height_m=\"307\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53619326403_f281b12ff8_o.jpg\"
+      height_o=\"1889\" width_o=\"3072\" url_q=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_b.jpg\"
+      height_l=\"630\" width_l=\"1024\" pathalias=\"\">\n\t\t<description>originally
+      from\n\n&lt;a href=&quot;https://www.flickr.com/photos/calliope/albums/72157605414248215/&quot;&gt;www.flickr.com/photos/calliope/albums/72157605414248215/&lt;/a&gt;\n\nUsed
+      with permission</description>\n\t</photo>\n\t<photo id=\"53619455629\" owner=\"200049760@N08\"
+      secret=\"3305808683\" server=\"65535\" farm=\"66\" title=\"poppy bud\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"7\" safety_level=\"0\" dateupload=\"1711743633\"
+      datetaken=\"2014-05-24 15:26:23\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"CommonsTestAccount\" count_views=\"92\" count_comments=\"0\" tags=\"\"
+      originalsecret=\"78fe42ff24\" originalformat=\"jpg\" latitude=\"0\" longitude=\"0\"
+      accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53619455629_3305808683_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53619455629_3305808683_t.jpg\"
+      height_t=\"73\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53619455629_3305808683_m.jpg\"
+      height_s=\"175\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53619455629_3305808683.jpg\"
+      height_m=\"366\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53619455629_78fe42ff24_o.jpg\"
+      height_o=\"2392\" width_o=\"3272\" url_q=\"https://live.staticflickr.com/65535/53619455629_3305808683_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53619455629_3305808683_b.jpg\"
+      height_l=\"749\" width_l=\"1024\" pathalias=\"\">\n\t\t<description>originally
+      from\n\n&lt;a href=&quot;https://www.flickr.com/photos/calliope/albums/72157605414248215/&quot;&gt;www.flickr.com/photos/calliope/albums/72157605414248215/&lt;/a&gt;\n\nUsed
+      with permission</description>\n\t</photo>\n\t<photo id=\"53619455489\" owner=\"200049760@N08\"
+      secret=\"62cbc9d4d3\" server=\"65535\" farm=\"66\" title=\"poppy\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"7\" safety_level=\"0\" dateupload=\"1711743628\"
+      datetaken=\"2008-06-03 08:13:47\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"CommonsTestAccount\" count_views=\"88\" count_comments=\"0\" tags=\"\"
+      originalsecret=\"621022cd9f\" originalformat=\"jpg\" latitude=\"0\" longitude=\"0\"
+      accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_t.jpg\"
+      height_t=\"66\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_m.jpg\"
+      height_s=\"159\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3.jpg\"
+      height_m=\"332\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53619455489_621022cd9f_o.jpg\"
+      height_o=\"2156\" width_o=\"3248\" url_q=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_b.jpg\"
+      height_l=\"680\" width_l=\"1024\" pathalias=\"\">\n\t\t<description>originally
+      from\n\n&lt;a href=&quot;https://www.flickr.com/photos/calliope/albums/72157605414248215/&quot;&gt;www.flickr.com/photos/calliope/albums/72157605414248215/&lt;/a&gt;\n\nUsed
+      with permission</description>\n\t</photo>\n\t<photo id=\"53586083948\" owner=\"200049760@N08\"
+      secret=\"c3039635cb\" server=\"65535\" farm=\"66\" title=\"Thomas E. Askew self-portrait\"
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"7\" safety_level=\"0\"
+      dateupload=\"1710360591\" datetaken=\"2024-03-13 15:08:43\" datetakengranularity=\"0\"
+      datetakenunknown=\"1\" ownername=\"CommonsTestAccount\" count_views=\"123\"
+      count_comments=\"0\" tags=\"thomaseaskew libraryofcongress photographers\" originalsecret=\"ba2d523910\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_t.jpg\"
+      height_t=\"100\" width_t=\"69\" url_s=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_m.jpg\"
+      height_s=\"240\" width_s=\"166\" url_m=\"https://live.staticflickr.com/65535/53586083948_c3039635cb.jpg\"
+      height_m=\"500\" width_m=\"346\" url_o=\"https://live.staticflickr.com/65535/53586083948_ba2d523910_o.jpg\"
+      height_o=\"3681\" width_o=\"2547\" url_q=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_b.jpg\"
+      height_l=\"1024\" width_l=\"709\" pathalias=\"\">\n\t\t<description>From the
+      Library of Congress. Using in a blog post.\n\n&lt;a href=&quot;https://loc.gov/pictures/resource/cph.3c24795/&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;loc.gov/pictures/resource/cph.3c24795/&lt;/a&gt;</description>\n\t</photo>\n\t<photo
+      id=\"53496509775\" owner=\"200049760@N08\" secret=\"60f3bd5461\" server=\"65535\"
+      farm=\"66\" title=\"Lotus Blossom\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"7\" safety_level=\"0\" dateupload=\"1706554808\" datetaken=\"2014-07-11
+      09:58:06\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"CommonsTestAccount\"
+      count_views=\"235\" count_comments=\"0\" tags=\"\" originalsecret=\"3de5cc61aa\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_t.jpg\"
+      height_t=\"82\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_m.jpg\"
+      height_s=\"198\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461.jpg\"
+      height_m=\"412\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53496509775_3de5cc61aa_o.jpg\"
+      height_o=\"2469\" width_o=\"3000\" url_q=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_b.jpg\"
+      height_l=\"843\" width_l=\"1024\" pathalias=\"\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"53495199922\" owner=\"200049760@N08\" secret=\"3de5cc61aa\" server=\"65535\"
+      farm=\"66\" title=\"Lotis Blossom\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"7\" safety_level=\"0\" dateupload=\"1706554808\" datetaken=\"2014-07-11
+      10:21:00\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"CommonsTestAccount\"
+      count_views=\"230\" count_comments=\"0\" tags=\"lotus flowers\" originalsecret=\"fae534e93d\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_t.jpg\"
+      height_t=\"79\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_m.jpg\"
+      height_s=\"190\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa.jpg\"
+      height_m=\"397\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53495199922_fae534e93d_o.jpg\"
+      height_o=\"2522\" width_o=\"3180\" url_q=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_b.jpg\"
+      height_l=\"812\" width_l=\"1024\" pathalias=\"\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"53496509590\" owner=\"200049760@N08\" secret=\"f4b4505da3\" server=\"65535\"
+      farm=\"66\" title=\"American Lotus\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"7\" safety_level=\"0\" dateupload=\"1706554807\" datetaken=\"2007-08-05
+      13:15:19\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"CommonsTestAccount\"
+      count_views=\"218\" count_comments=\"0\" tags=\"\" originalsecret=\"347874c2f8\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_t.jpg\"
+      height_t=\"64\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_m.jpg\"
+      height_s=\"154\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3.jpg\"
+      height_m=\"321\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53496509590_347874c2f8_o.jpg\"
+      height_o=\"2063\" width_o=\"3213\" url_q=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_b.jpg\"
+      height_l=\"657\" width_l=\"1024\" pathalias=\"\">\n\t\t<description />\n\t</photo>\n</photos>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 01 May 2024 10:10:49 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 54b736c8a06d70ac689481ee738cbc60.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Xm6ZG_WIZPVV11KuK1ChvVtYhouTJd0dIira8xFQRsY8CriHO8CS4g==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Fri, 31-May-2024 10:10:49 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Fri, 31-May-2024 10:10:49 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66321529-78d6897f0b182ae10d4a3efb;Root=1-66321529-618b1f2001d0affe04d8a788
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.32.246
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
+      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
+      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+      />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 01 May 2024 10:10:49 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 54b736c8a06d70ac689481ee738cbc60.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 7Wzi_iUgw3KNIxMdnDzhgEago9dEZ_CFVzB_rkIF-6G2AD4_z4G1Og==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Fri, 31-May-2024 10:10:49 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66321529-079481014b82caec6a6a0b1b;Root=1-66321529-65033bca2e5860f477d68cac
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.13.106
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestGetPhotosInUserPhotostream.test_no_realname_is_none.yml
+++ b/tests/fixtures/cassettes/TestGetPhotosInUserPhotostream.test_no_realname_is_none.yml
@@ -1,0 +1,229 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Coriginal_format%2Cowner_name%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o%2Ctags%2Cgeo%2Curl_q%2Curl_l%2Cdescription%2Csafety_level%2Crealname%2Cpath_alias%2Ccount_comments%2Ccount_views&method=flickr.people.getPublicPhotos&page=1&per_page=10&user_id=200049760%40N08
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photos
+      page=\"1\" pages=\"1\" perpage=\"10\" total=\"7\">\n\t<photo id=\"53619326403\"
+      owner=\"200049760@N08\" secret=\"3bc8ef2f43\" server=\"65535\" farm=\"66\" title=\"wet
+      poppy\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"7\" safety_level=\"0\"
+      dateupload=\"1711743634\" datetaken=\"2024-03-29 16:19:22\" datetakengranularity=\"0\"
+      datetakenunknown=\"1\" ownername=\"CommonsTestAccount\" count_views=\"93\" count_comments=\"0\"
+      tags=\"\" originalsecret=\"f281b12ff8\" originalformat=\"jpg\" latitude=\"0\"
+      longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_t.jpg\"
+      height_t=\"61\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_m.jpg\"
+      height_s=\"148\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43.jpg\"
+      height_m=\"307\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53619326403_f281b12ff8_o.jpg\"
+      height_o=\"1889\" width_o=\"3072\" url_q=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53619326403_3bc8ef2f43_b.jpg\"
+      height_l=\"630\" width_l=\"1024\" pathalias=\"\">\n\t\t<description>originally
+      from\n\n&lt;a href=&quot;https://www.flickr.com/photos/calliope/albums/72157605414248215/&quot;&gt;www.flickr.com/photos/calliope/albums/72157605414248215/&lt;/a&gt;\n\nUsed
+      with permission</description>\n\t</photo>\n\t<photo id=\"53619455629\" owner=\"200049760@N08\"
+      secret=\"3305808683\" server=\"65535\" farm=\"66\" title=\"poppy bud\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"7\" safety_level=\"0\" dateupload=\"1711743633\"
+      datetaken=\"2014-05-24 15:26:23\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"CommonsTestAccount\" count_views=\"92\" count_comments=\"0\" tags=\"\"
+      originalsecret=\"78fe42ff24\" originalformat=\"jpg\" latitude=\"0\" longitude=\"0\"
+      accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53619455629_3305808683_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53619455629_3305808683_t.jpg\"
+      height_t=\"73\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53619455629_3305808683_m.jpg\"
+      height_s=\"175\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53619455629_3305808683.jpg\"
+      height_m=\"366\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53619455629_78fe42ff24_o.jpg\"
+      height_o=\"2392\" width_o=\"3272\" url_q=\"https://live.staticflickr.com/65535/53619455629_3305808683_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53619455629_3305808683_b.jpg\"
+      height_l=\"749\" width_l=\"1024\" pathalias=\"\">\n\t\t<description>originally
+      from\n\n&lt;a href=&quot;https://www.flickr.com/photos/calliope/albums/72157605414248215/&quot;&gt;www.flickr.com/photos/calliope/albums/72157605414248215/&lt;/a&gt;\n\nUsed
+      with permission</description>\n\t</photo>\n\t<photo id=\"53619455489\" owner=\"200049760@N08\"
+      secret=\"62cbc9d4d3\" server=\"65535\" farm=\"66\" title=\"poppy\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"7\" safety_level=\"0\" dateupload=\"1711743628\"
+      datetaken=\"2008-06-03 08:13:47\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"CommonsTestAccount\" count_views=\"88\" count_comments=\"0\" tags=\"\"
+      originalsecret=\"621022cd9f\" originalformat=\"jpg\" latitude=\"0\" longitude=\"0\"
+      accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_t.jpg\"
+      height_t=\"66\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_m.jpg\"
+      height_s=\"159\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3.jpg\"
+      height_m=\"332\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53619455489_621022cd9f_o.jpg\"
+      height_o=\"2156\" width_o=\"3248\" url_q=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53619455489_62cbc9d4d3_b.jpg\"
+      height_l=\"680\" width_l=\"1024\" pathalias=\"\">\n\t\t<description>originally
+      from\n\n&lt;a href=&quot;https://www.flickr.com/photos/calliope/albums/72157605414248215/&quot;&gt;www.flickr.com/photos/calliope/albums/72157605414248215/&lt;/a&gt;\n\nUsed
+      with permission</description>\n\t</photo>\n\t<photo id=\"53586083948\" owner=\"200049760@N08\"
+      secret=\"c3039635cb\" server=\"65535\" farm=\"66\" title=\"Thomas E. Askew self-portrait\"
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"7\" safety_level=\"0\"
+      dateupload=\"1710360591\" datetaken=\"2024-03-13 15:08:43\" datetakengranularity=\"0\"
+      datetakenunknown=\"1\" ownername=\"CommonsTestAccount\" count_views=\"123\"
+      count_comments=\"0\" tags=\"thomaseaskew libraryofcongress photographers\" originalsecret=\"ba2d523910\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_t.jpg\"
+      height_t=\"100\" width_t=\"69\" url_s=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_m.jpg\"
+      height_s=\"240\" width_s=\"166\" url_m=\"https://live.staticflickr.com/65535/53586083948_c3039635cb.jpg\"
+      height_m=\"500\" width_m=\"346\" url_o=\"https://live.staticflickr.com/65535/53586083948_ba2d523910_o.jpg\"
+      height_o=\"3681\" width_o=\"2547\" url_q=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53586083948_c3039635cb_b.jpg\"
+      height_l=\"1024\" width_l=\"709\" pathalias=\"\">\n\t\t<description>From the
+      Library of Congress. Using in a blog post.\n\n&lt;a href=&quot;https://loc.gov/pictures/resource/cph.3c24795/&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;loc.gov/pictures/resource/cph.3c24795/&lt;/a&gt;</description>\n\t</photo>\n\t<photo
+      id=\"53496509775\" owner=\"200049760@N08\" secret=\"60f3bd5461\" server=\"65535\"
+      farm=\"66\" title=\"Lotus Blossom\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"7\" safety_level=\"0\" dateupload=\"1706554808\" datetaken=\"2014-07-11
+      09:58:06\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"CommonsTestAccount\"
+      count_views=\"235\" count_comments=\"0\" tags=\"\" originalsecret=\"3de5cc61aa\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_t.jpg\"
+      height_t=\"82\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_m.jpg\"
+      height_s=\"198\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461.jpg\"
+      height_m=\"412\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53496509775_3de5cc61aa_o.jpg\"
+      height_o=\"2469\" width_o=\"3000\" url_q=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53496509775_60f3bd5461_b.jpg\"
+      height_l=\"843\" width_l=\"1024\" pathalias=\"\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"53495199922\" owner=\"200049760@N08\" secret=\"3de5cc61aa\" server=\"65535\"
+      farm=\"66\" title=\"Lotis Blossom\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"7\" safety_level=\"0\" dateupload=\"1706554808\" datetaken=\"2014-07-11
+      10:21:00\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"CommonsTestAccount\"
+      count_views=\"230\" count_comments=\"0\" tags=\"lotus flowers\" originalsecret=\"fae534e93d\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_t.jpg\"
+      height_t=\"79\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_m.jpg\"
+      height_s=\"190\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa.jpg\"
+      height_m=\"397\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53495199922_fae534e93d_o.jpg\"
+      height_o=\"2522\" width_o=\"3180\" url_q=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53495199922_3de5cc61aa_b.jpg\"
+      height_l=\"812\" width_l=\"1024\" pathalias=\"\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"53496509590\" owner=\"200049760@N08\" secret=\"f4b4505da3\" server=\"65535\"
+      farm=\"66\" title=\"American Lotus\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"7\" safety_level=\"0\" dateupload=\"1706554807\" datetaken=\"2007-08-05
+      13:15:19\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"CommonsTestAccount\"
+      count_views=\"218\" count_comments=\"0\" tags=\"\" originalsecret=\"347874c2f8\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_t.jpg\"
+      height_t=\"64\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_m.jpg\"
+      height_s=\"154\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3.jpg\"
+      height_m=\"321\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53496509590_347874c2f8_o.jpg\"
+      height_o=\"2063\" width_o=\"3213\" url_q=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53496509590_f4b4505da3_b.jpg\"
+      height_l=\"657\" width_l=\"1024\" pathalias=\"\">\n\t\t<description />\n\t</photo>\n</photos>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 01 May 2024 10:11:17 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 9e4ef84d8626e7ec2ca2411a9eeb43c4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fmDWPrxV4XGUbqvHhgMKfSEm5leXY4pM7HI_BOb8KNMkkxW_vFhETA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Fri, 31-May-2024 10:11:17 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Fri, 31-May-2024 10:11:17 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66321545-0dc088ac669faaa34864ad24;Root=1-66321545-20f88d0565367fa967420e18
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.26.197
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
+      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
+      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+      />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 01 May 2024 10:11:17 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 9e4ef84d8626e7ec2ca2411a9eeb43c4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6IuP9D9q3hdRwR8T_o6224JaiTGbFrE_ACE0UylgiPZ-ojRLkaD8Xg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Fri, 31-May-2024 10:11:17 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66321545-195da3f547ae6e32718f82ae;Root=1-66321545-0e45e253408a4831071e3c2b
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.37.32
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1


### PR DESCRIPTION
This is a bug I spotted while getting photos from the Commons Test account.