### PR TITLE
Add a test that we handle deleted users in this method correctly

### DIFF
--- a/tests/api/test_collection_methods.py
+++ b/tests/api/test_collection_methods.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flickr_photos_api import FlickrApi
+from flickr_photos_api import FlickrApi, ResourceNotFound
 from flickr_photos_api.types import (
     PhotosInAlbum,
     PhotosInGallery,
@@ -266,6 +266,12 @@ class TestGetPhotosInUserPhotostream:
 
         owner = result["photos"][0]["owner"]
         assert owner["path_alias"] is None
+
+    def test_handles_deleted_user(self, api: FlickrApi) -> None:
+        # This is the user ID of the Upper Midwest Jewish Archives, who deleted
+        # their Flickr account in May 2024.
+        with pytest.raises(ResourceNotFound):
+            api.get_photos_in_user_photostream(user_id="48143042@N05")
 
 
 def test_get_photos_in_group_pool(api: FlickrApi) -> None:

--- a/tests/fixtures/cassettes/TestGetPhotosInUserPhotostream.test_handles_deleted_user.yml
+++ b/tests/fixtures/cassettes/TestGetPhotosInUserPhotostream.test_handles_deleted_user.yml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Coriginal_format%2Cowner_name%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o%2Ctags%2Cgeo%2Curl_q%2Curl_l%2Cdescription%2Csafety_level%2Crealname%2Cpath_alias%2Ccount_comments%2Ccount_views&method=flickr.people.getPublicPhotos&page=1&per_page=10&user_id=48143042%40N05
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3LMQ6DMAwF0Lk5xZd3Ct06JOEUPQACp4oEDrJDxfHr/b0438eOH6vVJolez4nA
+        sratyjfR1cvwJsw5RLUT1peeqCx1pxwekVXhkr0RDnP/MVZI6yjtko0wehx95vAHx4HS1WgAAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Tue, 21 May 2024 08:07:33 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 40b76fea3127a1d583fbc11b2e091fc2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Mv6AbP-INTm8MpEIveUWlhugvxRC46JaNd3vBWehwIe3ojFXXJnCeg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Thu, 20-Jun-2024 08:07:33 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Thu, 20-Jun-2024 08:07:33 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-664c5645-6bec8b38244c312d49d9804e;Root=1-664c5645-7ade63b30a20837b5f017dd6
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.10.17
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
This is related to https://github.com/Flickr-Foundation/commons.flickr.org/issues/155 – I wasn't sure how we handle users who don't exist in this method. It turns out we already handle them correctly, and now we have a test to that effect. 🥳 