### PR TITLE
Get raw tag information from single-photo responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.7.0 - 2024-07-24
+
+*   Add support for raw tags.
+
+    When you look up a single photo with `get_single_photo()`, it now returns the raw tag values and other tag information in the `raw_tags` field.
+
 ## v2.6.2 - 2024-07-23
 
 *   Fix the name of the Stockholm Transport Museum when looked up using this library.

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -36,10 +36,11 @@ from .types import (
     GroupInfo,
     PhotoContext,
     SinglePhotoInfo,
+    Tag,
 )
 
 
-__version__ = "2.6.2"
+__version__ = "2.7.0"
 
 
 __all__ = [
@@ -76,6 +77,7 @@ __all__ = [
     "InsufficientPermissionsToComment",
     "PhotoContext",
     "PhotoIsPrivate",
+    "Tag",
     "UnrecognisedFlickrApiException",
     "UserDeleted",
     "__version__",

--- a/src/flickr_photos_api/types/__init__.py
+++ b/src/flickr_photos_api/types/__init__.py
@@ -64,6 +64,16 @@ class Comment(typing.TypedDict):
     date: datetime.datetime
 
 
+class Tag(typing.TypedDict):
+    raw_value: str
+    normalized_value: str
+
+    author_id: str
+    author_name: str
+
+    is_machine_tag: bool
+
+
 # Represents the safety level of a photo on Flickr.
 #
 # https://www.flickrhelp.com/hc/en-us/articles/4404064206996-Content-filters#h_01HBRRKK6F4ZAW6FTWV8BPA2G7
@@ -92,6 +102,7 @@ class SinglePhotoInfo(typing.TypedDict):
     description: str | None
     tags: list[str]
     machine_tags: MachineTags
+    raw_tags: typing.NotRequired[list[Tag]]
 
     date_posted: datetime.datetime
     date_taken: DateTaken | None

--- a/tests/api/test_single_photo_methods.py
+++ b/tests/api/test_single_photo_methods.py
@@ -159,6 +159,35 @@ class TestGetSinglePhoto:
 
         assert photo["owner"]["realname"] == "Stockholm Transport Museum"
 
+    def test_gets_raw_tag_information(self, api: FlickrApi) -> None:
+        photo = api.get_single_photo(photo_id="21609597615")
+
+        assert photo["tags"] == ["church", "wesleyanchurch", "geo:locality=ngaruawahia"]
+
+        assert photo["raw_tags"] == [
+            {
+                "author_id": "126912357@N06",
+                "author_name": "valuable basket",
+                "raw_value": "Church",
+                "normalized_value": "church",
+                "is_machine_tag": False,
+            },
+            {
+                "author_id": "126912357@N06",
+                "author_name": "valuable basket",
+                "raw_value": "Wesleyan Church",
+                "normalized_value": "wesleyanchurch",
+                "is_machine_tag": False,
+            },
+            {
+                "author_id": "126912357@N06",
+                "author_name": "valuable basket",
+                "raw_value": "geo:locality=Ngaruawahia",
+                "normalized_value": "geo:locality=ngaruawahia",
+                "is_machine_tag": True,
+            },
+        ]
+
 
 class TestGetPhotoContexts:
     def test_gets_empty_lists_if_no_contexts(self, api: FlickrApi) -> None:

--- a/tests/fixtures/api_responses/32812033543.json
+++ b/tests/fixtures/api_responses/32812033543.json
@@ -23,6 +23,99 @@
   "location": null,
   "machine_tags": {
   },
+  "raw_tags": [
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "mascot",
+      "normalized_value": "mascot",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "Chief Bert",
+      "normalized_value": "chiefbert",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "German Shepherd",
+      "normalized_value": "germanshepherd",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "Station Elizabeth City",
+      "normalized_value": "stationelizabethcity",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "Week in the Life 2017",
+      "normalized_value": "weekinthelife2017",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "Nina Bowen",
+      "normalized_value": "ninabowen",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "D5",
+      "normalized_value": "d5",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "Mid-Atlantic",
+      "normalized_value": "midatlantic",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "North Carolina",
+      "normalized_value": "northcarolina",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "Elizabeth City",
+      "normalized_value": "elizabethcity",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "explosive detection dog",
+      "normalized_value": "explosivedetectiondog",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "United States",
+      "normalized_value": "unitedstates",
+      "is_machine_tag": false
+    },
+    {
+      "author_id": "30884892@N08",
+      "author_name": "U.S. Coast Guard",
+      "raw_value": "US",
+      "normalized_value": "us",
+      "is_machine_tag": false
+    }
+  ],
   "original_format": "jpg",
   "owner": {
     "id": "30884892@N08",

--- a/tests/fixtures/cassettes/TestGetSinglePhoto.test_gets_raw_tag_information.yml
+++ b/tests/fixtures/cassettes/TestGetSinglePhoto.test_gets_raw_tag_information.yml
@@ -1,0 +1,263 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=21609597615
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photo
+        id=\"21609597615\" secret=\"04b05f4473\" server=\"590\" farm=\"1\" dateuploaded=\"1442875605\"
+        isfavorite=\"0\" license=\"7\" safety_level=\"0\" rotation=\"0\" originalsecret=\"efe3a758a1\"
+        originalformat=\"jpg\" views=\"795\" media=\"photo\">\n\t<owner nsid=\"32741315@N06\"
+        username=\"National Library NZ on The Commons\" realname=\"\" location=\"Wellington,
+        New Zealand\" iconserver=\"3285\" iconfarm=\"4\" path_alias=\"nationallibrarynz_commons\">\n\t\t<gift
+        gift_eligible=\"\" new_flow=\"1\" />\n\t</owner>\n\t<title>Wesleyan Church
+        at Ngaruawahia, 1910 - Photograph taken by G &amp; C Ltd</title>\n\t<description>View
+        of the Wesleyan Church at Ngaruawahia. Photographed by G &amp;amp; C Ltd (Probably
+        Green &amp;amp; Colebrook, merchants, with a branch in Ngaruawahia)\nInscriptions:
+        Inscribed - Photographer&#039;s title on negative -bottom left: Wesleyan Church.
+        Ngaruawahia. 118bottom right: G &amp;amp; C Ltd. Protd 1.8.10.\nQuantity:
+        1 b&amp;amp;w original negative(s).\nPhysical Description: Dry plate glass
+        negative 4.5 x 6.5 inches \n\n Green &amp;amp; Colebrook (Firm). Wesleyan
+        Church at Ngaruawahia, 1910 - Photograph taken by G &amp;amp; C Ltd. Price,
+        William Archer, 1866-1948 :Collection of post card negatives. Ref: 1/2-000174-G.
+        Alexander Turnbull Library, Wellington, New Zealand. &lt;a href=&quot;http://natlib.govt.nz/records/22300671&quot;
+        rel=&quot;noreferrer nofollow&quot;&gt;natlib.govt.nz/records/22300671&lt;/a&gt;</description>\n\t<visibility
+        ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\n\t<dates posted=\"1442875605\"
+        taken=\"2004-12-31 13:09:04\" takengranularity=\"0\" takenunknown=\"1\" lastupdate=\"1637290621\"
+        />\n\t<editability cancomment=\"0\" canaddmeta=\"0\" />\n\t<publiceditability
+        cancomment=\"1\" canaddmeta=\"1\" />\n\t<usage candownload=\"1\" canblog=\"0\"
+        canprint=\"0\" canshare=\"1\" />\n\t<comments>0</comments>\n\t<notes />\n\t<people
+        haspeople=\"0\" />\n\t<tags>\n\t\t<tag id=\"32695993-21609597615-765\" author=\"126912357@N06\"
+        authorname=\"valuable basket\" raw=\"Church\" machine_tag=\"0\">church</tag>\n\t\t<tag
+        id=\"32695993-21609597615-905286\" author=\"126912357@N06\" authorname=\"valuable
+        basket\" raw=\"Wesleyan Church\" machine_tag=\"0\">wesleyanchurch</tag>\n\t\t<tag
+        id=\"32695993-21609597615-309676901\" author=\"126912357@N06\" authorname=\"valuable
+        basket\" raw=\"geo:locality=Ngaruawahia\" machine_tag=\"1\">geo:locality=ngaruawahia</tag>\n\t</tags>\n\t<urls>\n\t\t<url
+        type=\"photopage\">https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/</url>\n\t</urls>\n</photo>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 24 Jul 2024 14:34:02 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 8dbddccb44fea3c0ae7cceef434a136a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 9DmIay20zsowpEDg_w1MWEmX5nBMk81ydBIRXH-P7VMtk8SBFUzesQ==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Fri, 23-Aug-2024 14:34:01 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Fri, 23-Aug-2024 14:34:01 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-66a110d9-6050fcea22b93c173a66e063
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.13.25
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+        id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+        License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+        id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+        />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+        url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license
+        id=\"2\" name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+        />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+        url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license
+        id=\"5\" name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+        />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+        />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+        />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+        />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+        />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 24 Jul 2024 14:34:03 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 8dbddccb44fea3c0ae7cceef434a136a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - c64o2odI7RBUPE6RBaF_3Xzt8YoNcMxohtPkAAm17kDzAQKQqm3bnA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Fri, 23-Aug-2024 14:34:02 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-66a110da-46c95cc0449dc36d33a330e9
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.41.97
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=21609597615
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<sizes
+        canblog=\"0\" canprint=\"0\" candownload=\"1\">\n\t<size label=\"Square\"
+        width=\"75\" height=\"75\" source=\"https://live.staticflickr.com/590/21609597615_04b05f4473_s.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/sq/\"
+        media=\"photo\" />\n\t<size label=\"Large Square\" width=\"150\" height=\"150\"
+        source=\"https://live.staticflickr.com/590/21609597615_04b05f4473_q.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/q/\"
+        media=\"photo\" />\n\t<size label=\"Thumbnail\" width=\"73\" height=\"100\"
+        source=\"https://live.staticflickr.com/590/21609597615_04b05f4473_t.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/t/\"
+        media=\"photo\" />\n\t<size label=\"Small\" width=\"175\" height=\"240\" source=\"https://live.staticflickr.com/590/21609597615_04b05f4473_m.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/s/\"
+        media=\"photo\" />\n\t<size label=\"Small 320\" width=\"233\" height=\"320\"
+        source=\"https://live.staticflickr.com/590/21609597615_04b05f4473_n.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/n/\"
+        media=\"photo\" />\n\t<size label=\"Small 400\" width=\"291\" height=\"400\"
+        source=\"https://live.staticflickr.com/590/21609597615_04b05f4473_w.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/w/\"
+        media=\"photo\" />\n\t<size label=\"Medium\" width=\"364\" height=\"500\"
+        source=\"https://live.staticflickr.com/590/21609597615_04b05f4473.jpg\" url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/m/\"
+        media=\"photo\" />\n\t<size label=\"Medium 640\" width=\"465\" height=\"640\"
+        source=\"https://live.staticflickr.com/590/21609597615_04b05f4473_z.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/z/\"
+        media=\"photo\" />\n\t<size label=\"Medium 800\" width=\"582\" height=\"800\"
+        source=\"https://live.staticflickr.com/590/21609597615_04b05f4473_c.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/c/\"
+        media=\"photo\" />\n\t<size label=\"Large\" width=\"745\" height=\"1024\"
+        source=\"https://live.staticflickr.com/590/21609597615_04b05f4473_b.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/l/\"
+        media=\"photo\" />\n\t<size label=\"Large 1600\" width=\"1164\" height=\"1600\"
+        source=\"https://live.staticflickr.com/590/21609597615_4829de41a2_h.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/h/\"
+        media=\"photo\" />\n\t<size label=\"Large 2048\" width=\"1489\" height=\"2048\"
+        source=\"https://live.staticflickr.com/590/21609597615_d2ef496327_k.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/k/\"
+        media=\"photo\" />\n\t<size label=\"X-Large 3K\" width=\"2234\" height=\"3072\"
+        source=\"https://live.staticflickr.com/590/21609597615_d52dd8d1d9_3k.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/3k/\"
+        media=\"photo\" />\n\t<size label=\"X-Large 4K\" width=\"2979\" height=\"4096\"
+        source=\"https://live.staticflickr.com/590/21609597615_693eb51ffc_4k.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/4k/\"
+        media=\"photo\" />\n\t<size label=\"X-Large 5K\" width=\"3724\" height=\"5120\"
+        source=\"https://live.staticflickr.com/590/21609597615_fbf45c8d27_5k.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/5k/\"
+        media=\"photo\" />\n\t<size label=\"X-Large 6K\" width=\"4468\" height=\"6144\"
+        source=\"https://live.staticflickr.com/590/21609597615_2ba85d2d3a_6k.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/6k/\"
+        media=\"photo\" />\n\t<size label=\"Original\" width=\"4683\" height=\"6439\"
+        source=\"https://live.staticflickr.com/590/21609597615_efe3a758a1_o.jpg\"
+        url=\"https://www.flickr.com/photos/nationallibrarynz_commons/21609597615/sizes/o/\"
+        media=\"photo\" />\n</sizes>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Wed, 24 Jul 2024 14:34:03 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 8dbddccb44fea3c0ae7cceef434a136a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - bNlWmbrdDN9-4Bjc0qykdRkZeNVu6b1AdzyW7iOM4jxqzqMBvRhKbA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Fri, 23-Aug-2024 14:34:03 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-66a110db-12f3cb865ae86410067b85f6
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.13.186
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
This information was already being returned from the Flickr API, we just weren't decoding it into this library's output. Let's do that!

This is required for Data Lifeboat.