### PR TITLE
Get visibility information from single-photo responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.8.0 - 2024-07-25
+
+*   Add support for visibility.
+
+    When you look up a single photo with `get_single_photo()`, it now returns information about the photo's visibility (is it public, private, friends/family only).
+
 ## v2.7.0 - 2024-07-24
 
 *   Add support for raw tags.

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -37,10 +37,11 @@ from .types import (
     PhotoContext,
     SinglePhotoInfo,
     Tag,
+    Visibility,
 )
 
 
-__version__ = "2.7.0"
+__version__ = "2.8.0"
 
 
 __all__ = [
@@ -80,5 +81,6 @@ __all__ = [
     "Tag",
     "UnrecognisedFlickrApiException",
     "UserDeleted",
+    "Visibility",
     "__version__",
 ]

--- a/src/flickr_photos_api/api/single_photo_methods.py
+++ b/src/flickr_photos_api/api/single_photo_methods.py
@@ -15,6 +15,7 @@ from ..types import (
     SinglePhoto,
     Size,
     Tag,
+    Visibility,
     create_user,
     get_machine_tags,
 )
@@ -163,6 +164,19 @@ class SinglePhotoMethods(LicenseMethods):
         else:
             location = None
 
+        # Get visibility information about the photo.
+        #
+        # This is returned in the form:
+        #
+        #     <visibility ispublic="1" isfriend="0" isfamily="0"/>
+        #
+        visibility_elem = find_required_elem(photo_elem, path="visibility")
+        visibility: Visibility = {
+            "is_public": visibility_elem.attrib["ispublic"] == "1",
+            "is_friend": visibility_elem.attrib["isfriend"] == "1",
+            "is_family": visibility_elem.attrib["isfamily"] == "1",
+        }
+
         return {
             "id": photo_id,
             "secret": photo_elem.attrib["secret"],
@@ -183,6 +197,7 @@ class SinglePhotoMethods(LicenseMethods):
             "count_comments": count_comments,
             "count_views": count_views,
             "url": url,
+            "visibility": visibility,
         }
 
     def _get_single_photo_sizes(self, *, photo_id: str) -> list[Size]:

--- a/src/flickr_photos_api/types/__init__.py
+++ b/src/flickr_photos_api/types/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "PhotoContext",
     "User",
     "UserInfo",
+    "Visibility",
     "create_user",
     "get_machine_tags",
 ]
@@ -74,6 +75,12 @@ class Tag(typing.TypedDict):
     is_machine_tag: bool
 
 
+class Visibility(typing.TypedDict):
+    is_public: bool
+    is_friend: bool
+    is_family: bool
+
+
 # Represents the safety level of a photo on Flickr.
 #
 # https://www.flickrhelp.com/hc/en-us/articles/4404064206996-Content-filters#h_01HBRRKK6F4ZAW6FTWV8BPA2G7
@@ -110,6 +117,8 @@ class SinglePhotoInfo(typing.TypedDict):
 
     count_comments: int
     count_views: int
+
+    visibility: typing.NotRequired[Visibility]
 
     url: str
 

--- a/tests/fixtures/api_responses/32812033543.json
+++ b/tests/fixtures/api_responses/32812033543.json
@@ -237,5 +237,10 @@
     "us"
   ],
   "title": "Puppy Kisses",
-  "url": "https://www.flickr.com/photos/coast_guard/32812033543/"
+  "url": "https://www.flickr.com/photos/coast_guard/32812033543/",
+  "visibility": {
+    "is_public": true,
+    "is_friend": false,
+    "is_family": false
+  }
 }


### PR DESCRIPTION
It's already being returned from the Flickr API, but we weren't mapping it into our return values.  This is required for Data Lifeboat.