### PR TITLE
Fetch the user's buddy icon as part of `get_user(user_id)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.9.0 - 2024-08-13
+
+*   Remove the `get_buddy_icon_url(user_id)` method.
+
+    Instead, call `get_user(user_id)` and read the `buddy_icon_url` parameter from the response.
+
+    If you already have a result from `get_user(user_id)`, use that to save yourself an API call.
+
 ## v2.8.1 - 2024-08-07
 
 *   Internal refactoring to make it slightly easier to "override" user `realname` values that get returned from the API.

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -41,7 +41,7 @@ from .types import (
 )
 
 
-__version__ = "2.8.1"
+__version__ = "2.9.0"
 
 
 __all__ = [

--- a/src/flickr_photos_api/types/users.py
+++ b/src/flickr_photos_api/types/users.py
@@ -14,6 +14,7 @@ class UserInfo(User):
     description: str | None
     has_pro_account: bool
     count_photos: int
+    buddy_icon_url: str
 
 
 def create_user(

--- a/tests/api/test_user_methods.py
+++ b/tests/api/test_user_methods.py
@@ -22,6 +22,7 @@ class TestGetUser:
             "path_alias": "alexwlchan",
             "photos_url": "https://www.flickr.com/photos/alexwlchan/",
             "profile_url": "https://www.flickr.com/people/alexwlchan/",
+            "buddy_icon_url": "https://farm66.staticflickr.com/65535/buddyicons/199258389@N04.jpg",
             "description": "Tech lead at the Flickr Foundation.",
             "has_pro_account": False,
             "count_photos": 1,
@@ -39,6 +40,7 @@ class TestGetUser:
             "path_alias": None,
             "photos_url": "https://www.flickr.com/photos/199246608@N02/",
             "profile_url": "https://www.flickr.com/people/199246608@N02/",
+            "buddy_icon_url": "https://www.flickr.com/images/buddyicon.gif",
             "count_photos": 38,
         }
 
@@ -178,4 +180,4 @@ class TestEnsureUserId:
     ],
 )
 def test_get_buddy_icon_url(api: FlickrApi, user_id: str, expected_url: str) -> None:
-    assert api.get_buddy_icon_url(user_id=user_id) == expected_url
+    assert api.get_user(user_id=user_id)["buddy_icon_url"] == expected_url


### PR DESCRIPTION
I'm about to use this in the Commons Admin and I knew I wanted to ditch the old method; I'm doing it now to avoid making use of a method that's deprecated (in my heart, if not in my code).

Part of https://github.com/Flickr-Foundation/commons.flickr.org/issues/233