### PR TITLE
Allow subclassing the `UserInfo` type again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v2.11.2 - 2024-09-02
+
+*   Change the `UserInfo` type so it can be subclassed again (this broke in v2.10.0).
+    This doesn't change the output/behaviour of the library.
+
 ## v2.11.1 - 2024-09-02
 
 *   Internal refactoring for Flickr Foundation purposes; no public-facing changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,5 @@ strict = true
 
 [tool.interrogate]
 # fail_under = 100
-fail_under = 36
+fail_under = 38
 omit-covered-files = true

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -41,7 +41,7 @@ from .types import (
 )
 
 
-__version__ = "2.11.1"
+__version__ = "2.11.2"
 
 
 __all__ = [

--- a/src/flickr_photos_api/api/user_methods.py
+++ b/src/flickr_photos_api/api/user_methods.py
@@ -210,36 +210,25 @@ class UserMethods(FlickrApi):
         #
         location = find_optional_text(person_elem, path="location")
 
+        user: UserInfo = {
+            "id": user_id,
+            "username": username,
+            "realname": realname,
+            "description": description,
+            "location": location,
+            "path_alias": path_alias,
+            "photos_url": photos_url,
+            "profile_url": profile_url,
+            "buddy_icon_url": buddy_icon_url,
+            "count_photos": count_photos,
+            "has_pro_account": has_pro_account,
+        }
+
         if has_pro_account:
             assert pro_account_expires is not None
-            return {
-                "id": user_id,
-                "username": username,
-                "realname": realname,
-                "description": description,
-                "location": location,
-                "path_alias": path_alias,
-                "photos_url": photos_url,
-                "profile_url": profile_url,
-                "buddy_icon_url": buddy_icon_url,
-                "count_photos": count_photos,
-                "has_pro_account": True,
-                "pro_account_expires": pro_account_expires,
-            }
-        else:
-            return {
-                "id": user_id,
-                "username": username,
-                "realname": realname,
-                "description": description,
-                "location": location,
-                "path_alias": path_alias,
-                "photos_url": photos_url,
-                "profile_url": profile_url,
-                "buddy_icon_url": buddy_icon_url,
-                "count_photos": count_photos,
-                "has_pro_account": False,
-            }
+            user["pro_account_expires"] = pro_account_expires
+
+        return user
 
     def _lookup_user_id_for_user_url(self, *, user_url: str) -> str:
         """


### PR DESCRIPTION
For https://github.com/Flickr-Foundation/commons.flickr.org/issues/233 and https://github.com/Flickr-Foundation/infrastructure/issues/42