### PR TITLE
Bump all the dev dependencies

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,30 +4,30 @@
     # via -r dev_requirements.in
 annotated-types==0.7.0
     # via pydantic
-anyio==4.4.0
+anyio==4.8.0
     # via httpx
-attrs==24.2.0
+attrs==25.1.0
     # via interrogate
-authlib==1.3.1
+authlib==1.4.1
     # via flickr-photos-api
-build==1.2.1
+build==1.2.2.post1
     # via -r dev_requirements.in
-certifi==2024.6.2
+certifi==2025.1.31
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via interrogate
 colorama==0.4.6
     # via interrogate
-coverage==7.5.3
+coverage==7.6.10
     # via pytest-cov
-cryptography==42.0.8
+cryptography==44.0.0
     # via authlib
 docutils==0.21.2
     # via readme-renderer
@@ -35,119 +35,118 @@ flickr-url-parser==1.10.0
     # via flickr-photos-api
 h11==0.14.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.1
     # via
     #   flickr-photos-api
     #   flickr-url-parser
 hyperlink==21.0.0
     # via flickr-url-parser
-idna==3.7
+id==1.5.0
+    # via twine
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   hyperlink
     #   requests
     #   yarl
-importlib-metadata==7.1.0
-    # via twine
 iniconfig==2.0.0
     # via pytest
 interrogate==1.7.0
     # via -r dev_requirements.in
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==5.3.0
+jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.0.1
+jaraco-functools==4.1.0
     # via keyring
-keyring==25.2.1
+keyring==25.6.0
     # via twine
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.2.0
+more-itertools==10.6.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-multidict==6.0.5
+multidict==6.1.0
     # via yarl
-mypy==1.10.0
+mypy==1.15.0
     # via -r dev_requirements.in
 mypy-extensions==1.0.0
     # via mypy
-nh3==0.2.17
+nh3==0.2.20
     # via readme-renderer
-packaging==24.0
+packaging==24.2
     # via
     #   build
     #   pytest
-pkginfo==1.11.0
-    # via twine
+    #   twine
 pluggy==1.5.0
     # via pytest
+propcache==0.2.1
+    # via yarl
 py==1.11.0
     # via interrogate
 pycparser==2.22
     # via cffi
-pydantic==2.7.4
+pydantic==2.10.6
     # via -r dev_requirements.in
-pydantic-core==2.18.4
+pydantic-core==2.27.2
     # via pydantic
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   readme-renderer
     #   rich
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via build
-pytest==8.2.1
+pytest==8.3.4
     # via pytest-cov
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r dev_requirements.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via vcrpy
-readme-renderer==43.0
+readme-renderer==44.0
     # via twine
 requests==2.32.3
     # via
+    #   id
     #   requests-toolbelt
     #   twine
 requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.7.1
+rich==13.9.4
     # via twine
-ruff==0.4.8
+ruff==0.9.5
     # via -r dev_requirements.in
-silver-nitrate==1.1.1
+silver-nitrate==1.4.0
     # via flickr-photos-api
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 tabulate==0.9.0
     # via interrogate
-tenacity==8.3.0
+tenacity==9.0.0
     # via flickr-photos-api
-twine==5.1.0
+twine==6.1.0
     # via -r dev_requirements.in
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via
     #   mypy
     #   pydantic
     #   pydantic-core
-urllib3==2.2.1
+urllib3==2.3.0
     # via
     #   requests
     #   twine
-vcrpy==6.0.1
+    #   vcrpy
+vcrpy==7.0.0
     # via -r dev_requirements.in
-wrapt==1.16.0
+wrapt==1.17.2
     # via vcrpy
-yarl==1.9.4
+yarl==1.18.3
     # via vcrpy
-zipp==3.19.1
-    # via importlib-metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ show_missing = true
 skip_covered = true
 fail_under = 100
 exclude_also = [
-  "return NotImplemented",
+  "raise NotImplementedError",
 ]
 
 [tool.pytest.ini_options]

--- a/src/flickr_photos_api/api/base.py
+++ b/src/flickr_photos_api/api/base.py
@@ -58,7 +58,7 @@ class FlickrApi(abc.ABC):
         :param exceptions: A map from Flickr API error code to exceptions that should
             be thrown.
         """
-        return NotImplemented
+        raise NotImplementedError
 
 
 def is_retryable(exc: BaseException) -> bool:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,10 +5,10 @@ These functions are *not* part of the published library, and are
 just for use in the flickr-photos-api tests.
 """
 
-import os
+from pathlib import Path
 import typing
 
-from nitrate.json import DatetimeDecoder
+from nitrate.json import NitrateDecoder
 from nitrate.types import read_typed_json
 
 T = typing.TypeVar("T")
@@ -18,8 +18,10 @@ def get_fixture(filename: str, *, model: type[T]) -> T:
     """
     Read a JSON fixture and check it's the right type.
     """
+    fixtures_dir = Path("tests/fixtures/api_responses")
+
     return read_typed_json(
-        os.path.join("tests/fixtures/api_responses", filename),
+        fixtures_dir / filename,
         model=model,
-        cls=DatetimeDecoder,
+        cls=NitrateDecoder,
     )


### PR DESCRIPTION
I was having issues installing Pydantic with Python 3.13, and it's because we have a really old version.  Let's upgrade everything.