### PR TITLE
Allow passing an `int` as query parameter value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v2.16.2
+## v2.16.2 - 2025-02-28
 
 *   Add an optional `client` argument to `download_file`, so you can supply your own `httpx.Client` if, for example, you want to override the User-Agent header.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## v2.17.0 - 2025-04-07
+
+*   Change the type hint on `FlickrApi.call`, so now `params` can take `str` or `int` values, not just `str`.
+
+    This means you can pass numeric values directly to the API, rather than casting them to `str` first -- for example:
+
+    ```python
+    FlickrApi.call(method="…", params={"page": 1, …})
+    ```
+
+    rather than:
+
+    ```python
+    FlickrApi.call(method="…", params={"page": str(1), …})
+    ```
+
 ## v2.16.2 - 2025-02-28
 
 *   Add an optional `client` argument to `download_file`, so you can supply your own `httpx.Client` if, for example, you want to override the User-Agent header.

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -43,7 +43,7 @@ from .types import (
 )
 
 
-__version__ = "2.16.2"
+__version__ = "2.17.0"
 
 
 __all__ = [

--- a/src/flickr_photos_api/api/base.py
+++ b/src/flickr_photos_api/api/base.py
@@ -43,7 +43,7 @@ class FlickrApi(abc.ABC):
         *,
         http_method: HttpMethod = "GET",
         method: str,
-        params: dict[str, str] | None = None,
+        params: dict[str, str | int] | None = None,
         exceptions: dict[str, Exception] | None = None,
     ) -> ET.Element:
         """
@@ -148,7 +148,7 @@ class HttpxImplementation(FlickrApi):
         *,
         http_method: HttpMethod = "GET",
         method: str,
-        params: dict[str, str] | None = None,
+        params: dict[str, str | int] | None = None,
         exceptions: dict[str, Exception] | None = None,
     ) -> ET.Element:
         """
@@ -183,7 +183,7 @@ class HttpxImplementation(FlickrApi):
         *,
         http_method: HttpMethod,
         method: str,
-        params: dict[str, str] | None,
+        params: dict[str, str | int] | None,
         exceptions: dict[str, Exception],
     ) -> ET.Element:
         """

--- a/src/flickr_photos_api/api/collection_methods.py
+++ b/src/flickr_photos_api/api/collection_methods.py
@@ -212,8 +212,8 @@ class CollectionMethods(LicenseMethods, UserMethods):
                 "user_id": user_id,
                 "photoset_id": album_id,
                 "extras": ",".join(self.extras),
-                "page": str(page),
-                "per_page": str(per_page),
+                "page": page,
+                "per_page": per_page,
             },
             exceptions={
                 "1": ResourceNotFound(f"Could not find album with ID: {album_id!r}"),
@@ -255,8 +255,8 @@ class CollectionMethods(LicenseMethods, UserMethods):
                 "gallery_id": gallery_id,
                 "get_gallery_info": "1",
                 "extras": ",".join(self.extras),
-                "page": str(page),
-                "per_page": str(per_page),
+                "page": page,
+                "per_page": per_page,
             },
             exceptions={
                 "1": ResourceNotFound(f"Could not find gallery with ID: {gallery_id!r}")
@@ -305,8 +305,8 @@ class CollectionMethods(LicenseMethods, UserMethods):
             params={
                 "user_id": user_id,
                 "extras": ",".join(self.extras),
-                "page": str(page),
-                "per_page": str(per_page),
+                "page": page,
+                "per_page": per_page,
             },
             exceptions={
                 "1": ResourceNotFound(f"Could not find user with ID: {user_id!r}")
@@ -370,8 +370,8 @@ class CollectionMethods(LicenseMethods, UserMethods):
             params={
                 "group_id": group_info["id"],
                 "extras": ",".join(self.extras),
-                "page": str(page),
-                "per_page": str(per_page),
+                "page": page,
+                "per_page": per_page,
             },
         )
 
@@ -396,8 +396,8 @@ class CollectionMethods(LicenseMethods, UserMethods):
             method="flickr.photos.search",
             params={
                 "tags": tag,
-                "page": str(page),
-                "per_page": str(per_page),
+                "page": page,
+                "per_page": per_page,
                 # This is so we get the same photos as you see on the "tag" page
                 # under "All Photos Tagged XYZ" -- if you click the URL to the
                 # full search results, you end up on a page like:

--- a/tests/api/test_user_methods.py
+++ b/tests/api/test_user_methods.py
@@ -198,7 +198,7 @@ class TestGetUser:
                 *,
                 http_method: typing.Any = None,
                 method: str,
-                params: dict[str, str] | None = None,
+                params: dict[str, str | int] | None = None,
                 exceptions: dict[str, Exception] | None = None,
             ) -> ET.Element:
                 """


### PR DESCRIPTION
We don't need to be strict about requiring `str` here, and I saw a comment from Dan last week explaining he had to work around this – let's make it so he doesn't.