### PR TITLE
Retry flaky "Sorry, the Flickr API service is not currently available" errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.17.1 - 2025-04-08
+
+*   Retry flaky errors *"Sorry, the Flickr API service is not currently available"* for any error code, not just error code 201.
+
 ## v2.17.0 - 2025-04-07
 
 *   Change the type hint on `FlickrApi.call`, so now `params` can take `str` or `int` values, not just `str`.

--- a/src/flickr_photos_api/__init__.py
+++ b/src/flickr_photos_api/__init__.py
@@ -43,7 +43,7 @@ from .types import (
 )
 
 
-__version__ = "2.17.0"
+__version__ = "2.17.1"
 
 
 __all__ = [

--- a/src/flickr_photos_api/api/base.py
+++ b/src/flickr_photos_api/api/base.py
@@ -97,10 +97,14 @@ def is_retryable(exc: BaseException) -> bool:
     #     />
     #
     # but this indicates a flaky connection rather than a genuine failure.
+    #
+    # We've seen similar with code "0", so we match on the error message
+    # rather than the code.
     if (
         isinstance(exc, UnrecognisedFlickrApiException)
         and isinstance(exc.args[0], dict)
-        and exc.args[0].get("code") == "201"
+        and exc.args[0].get("msg")
+        == "Sorry, the Flickr API service is not currently available."
     ):
         return True
 


### PR DESCRIPTION
These caused some errors in the scheduled tasks in the Commons Explorer yesterday, and maybe more retrying will fix it.