### PR TITLE
Add a method to get the license history of a photo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.3 - 2025-05-01
+
+Add a new method `get_license_history(photo_id)`, which returns the license history of a photo with our nicely-typed `License` model.
+
 ## v3.2 - 2025-04-30
 
 Return more information about photo locations.

--- a/src/flickr_api/__init__.py
+++ b/src/flickr_api/__init__.py
@@ -13,7 +13,7 @@ from .exceptions import (
 )
 
 
-__version__ = "3.2"
+__version__ = "3.3"
 
 
 __all__ = [

--- a/src/flickr_api/api/single_photo_methods.py
+++ b/src/flickr_api/api/single_photo_methods.py
@@ -48,7 +48,6 @@ class SinglePhotoMethods(LicenseMethods):
         """
         # The getInfo response is a blob of XML of the form:
         #
-        #       <?xml version="1.0" encoding="utf-8" ?>
         #       <rsp stat="ok">
         #       <photo license="8" …>
         #           <owner

--- a/src/flickr_api/models/__init__.py
+++ b/src/flickr_api/models/__init__.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import typing
 
 from .contexts import AlbumContext, GalleryContext, GroupContext, PhotoContext
-from .licenses import License, LicenseId
+from .licenses import License, LicenseId, LicenseChange
 from .machine_tags import MachineTags
 from .photo import (
     Location,
@@ -21,6 +21,7 @@ __all__ = [
     "GroupContext",
     "License",
     "LicenseId",
+    "LicenseChange",
     "Location",
     "LocationContext",
     "MachineTags",

--- a/src/flickr_api/models/licenses.py
+++ b/src/flickr_api/models/licenses.py
@@ -2,6 +2,7 @@
 Types for the licenses used on Flickr.
 """
 
+from datetime import datetime
 import typing
 
 
@@ -31,3 +32,24 @@ LicenseId = typing.Literal[
     "cc0-1.0",
     "pdm",
 ]
+
+
+class LicenseChangeEntry:
+    """
+    Events in the license history of a photo -- both the initial license
+    and any subsequent changes.
+    """
+
+    # The initial license, set when the photo was uploaded
+    InitialLicense = typing.TypedDict(
+        "InitialLicense", {"date_posted": datetime, "license": License}
+    )
+
+    # Any changes to the license made after the initial upload
+    ChangedLicense = typing.TypedDict(
+        "ChangedLicense",
+        {"date_changed": datetime, "old_license": License, "new_license": License},
+    )
+
+
+LicenseChange = LicenseChangeEntry.InitialLicense | LicenseChangeEntry.ChangedLicense

--- a/src/flickr_api/models/licenses.py
+++ b/src/flickr_api/models/licenses.py
@@ -16,7 +16,7 @@ class License(typing.TypedDict):
 
     id: "LicenseId"
     label: str
-    url: str | None
+    url: str
 
 
 LicenseId = typing.Literal[

--- a/tests/api/test_license_methods.py
+++ b/tests/api/test_license_methods.py
@@ -2,9 +2,11 @@
 Tests for ``flickr_api.api.licenses``.
 """
 
+from datetime import datetime, timezone
+
 import pytest
 
-from flickr_api import FlickrApi, LicenseNotFound
+from flickr_api import FlickrApi, LicenseNotFound, ResourceNotFound
 
 
 class TestLicenseMethods:
@@ -104,3 +106,100 @@ class TestLicenseMethods:
         """
         with pytest.raises(LicenseNotFound, match=bad_id):
             api.lookup_license_by_id(id=bad_id)
+
+
+class TestGetLicenseHistory:
+    """
+    Tests for `get_license_history`.
+    """
+
+    def test_photo_with_initial_license(self, api: FlickrApi) -> None:
+        """
+        The license history of a photo which has the same license as
+        it was initially uploaded with has a single entry.
+        """
+        expected = [
+            {
+                "date_posted": datetime(2009, 9, 23, 21, 36, 56, tzinfo=timezone.utc),
+                "license": {
+                    "id": "nkcr",
+                    "label": "No known copyright restrictions",
+                    "url": "https://www.flickr.com/commons/usage/",
+                },
+            }
+        ]
+        actual = api.get_license_history(photo_id="3948976954")
+
+        assert expected == actual
+
+    def test_photo_with_single_license_change(self, api: FlickrApi) -> None:
+        """
+        The license history of a photo which has a single license change
+        has two entries: the initial license and the change.
+        """
+        expected = [
+            {
+                "date_changed": datetime(2025, 5, 1, 11, 15, 8, tzinfo=timezone.utc),
+                "old_license": {
+                    "id": "cc-by-2.0",
+                    "label": "CC BY 2.0",
+                    "url": "https://creativecommons.org/licenses/by/2.0/",
+                },
+                "new_license": {
+                    "id": "cc-by-sa-2.0",
+                    "label": "CC BY-SA 2.0",
+                    "url": "https://creativecommons.org/licenses/by-sa/2.0/",
+                },
+            },
+        ]
+        actual = api.get_license_history(photo_id="54049228596")
+
+        assert expected == actual
+
+    def test_photo_with_changed_license(self, api: FlickrApi) -> None:
+        """
+        The license history of a photo whose license has been edited
+        multiple times has multiple entries.
+        """
+        expected = [
+            {
+                "date_changed": datetime(2025, 4, 14, 2, 34, 50, tzinfo=timezone.utc),
+                "old_license": {
+                    "id": "all-rights-reserved",
+                    "label": "All Rights Reserved",
+                    "url": "https://www.flickrhelp.com/hc/en-us/articles/10710266545556-Using-Flickr-images-shared-by-other-members",
+                },
+                "new_license": {
+                    "id": "pdm",
+                    "label": "Public Domain Mark",
+                    "url": "https://creativecommons.org/publicdomain/mark/1.0/",
+                },
+            },
+            {
+                "date_changed": datetime(2025, 4, 17, 15, 58, 25, tzinfo=timezone.utc),
+                "old_license": {
+                    "id": "pdm",
+                    "label": "Public Domain Mark",
+                    "url": "https://creativecommons.org/publicdomain/mark/1.0/",
+                },
+                "new_license": {
+                    "id": "nkcr",
+                    "label": "No known copyright restrictions",
+                    "url": "https://www.flickr.com/commons/usage/",
+                },
+            },
+        ]
+        actual = api.get_license_history(photo_id="54450311696")
+
+        assert expected == actual
+
+    @pytest.mark.parametrize(
+        "photo_id", ["does_not_exist", "12345678901234567890", "-1"]
+    )
+    def test_non_existent_photo_is_error(self, api: FlickrApi, photo_id: str) -> None:
+        """
+        Looking up the license history of a non-existent photo is
+        an error.
+        """
+        with pytest.raises(ResourceNotFound):
+            api.get_license_history(photo_id)

--- a/tests/fixtures/cassettes/TestGetLicenseHistory.test_non_existent_photo_is_error[-1].yml
+++ b/tests/fixtures/cassettes/TestGetLicenseHistory.test_non_existent_photo_is_error[-1].yml
@@ -1,0 +1,129 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getLicenseHistory&photo_id=-1
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"fail\">\n\t<err
+        code=\"1\" msg=\"Photo not found\" />\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:09:57 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 56bcb1c1746cc96cff5943a0f457e6b0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - qoBaUdlyOhxPJ_iQL9haSIlOv14G-IjOqs6C46pjhGC_oCEd3vcreA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '105'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:09:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:09:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-68135684-1345cdff4efa95c351b96d93
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.21.174
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+        id=\"0\" name=\"All Rights Reserved\" url=\"https://www.flickrhelp.com/hc/en-us/articles/10710266545556-Using-Flickr-images-shared-by-other-members\"
+        />\n\t<license id=\"4\" name=\"Attribution License\" url=\"https://creativecommons.org/licenses/by/2.0/\"
+        />\n\t<license id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+        />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+        url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license
+        id=\"2\" name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+        />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+        url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license
+        id=\"5\" name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+        />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+        />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"https://www.usa.gov/government-copyright\"
+        />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+        />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+        />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:19:55 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 063bfb014e66ef670fc62ff044660cf2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ZaQckx6cmtfHmvtqj4HnFDEaBYgN4QPo_F4zvoSfBSGTBsEFMDWV9w==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '1360'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:55 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:55 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-681358db-11613e2747c695f44de99563
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.28.231
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/TestGetLicenseHistory.test_non_existent_photo_is_error[12345678901234567890].yml
+++ b/tests/fixtures/cassettes/TestGetLicenseHistory.test_non_existent_photo_is_error[12345678901234567890].yml
@@ -1,0 +1,129 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getLicenseHistory&photo_id=12345678901234567890
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"fail\">\n\t<err
+        code=\"1\" msg=\"Photo not found\" />\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:09:56 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 40e3ed7c6b85417046e956c87e47596a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - rK6WP2d38baLr39VO24DAMjyTd1E_47WJh_CF38hRr15UIYsCsV13w==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '105'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:09:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:09:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-68135684-0dfd93ab61e51177518d009f
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.5.125
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+        id=\"0\" name=\"All Rights Reserved\" url=\"https://www.flickrhelp.com/hc/en-us/articles/10710266545556-Using-Flickr-images-shared-by-other-members\"
+        />\n\t<license id=\"4\" name=\"Attribution License\" url=\"https://creativecommons.org/licenses/by/2.0/\"
+        />\n\t<license id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+        />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+        url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license
+        id=\"2\" name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+        />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+        url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license
+        id=\"5\" name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+        />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+        />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"https://www.usa.gov/government-copyright\"
+        />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+        />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+        />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:19:54 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 063bfb014e66ef670fc62ff044660cf2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - nan00NicrpKgNRNKyf35IjN2AyENIICdpTOxwsa-hkuBHcfy2lc0SA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '1360'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-681358da-5806544b3f647f6642f0728c
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.21.174
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/TestGetLicenseHistory.test_non_existent_photo_is_error[does_not_exist].yml
+++ b/tests/fixtures/cassettes/TestGetLicenseHistory.test_non_existent_photo_is_error[does_not_exist].yml
@@ -1,0 +1,129 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getLicenseHistory&photo_id=does_not_exist
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"fail\">\n\t<err
+        code=\"1\" msg=\"Photo not found\" />\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:09:55 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 718d744faad6ff02c7a7ca517a01865a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Bqt8o_L86V7-Ixbnl7ZpOxEcrFqTbh7-fM6G7kUo704ZubmzA4gAmw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '105'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:09:55 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:09:55 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-68135683-7b90e0b56fdb6bb3523c20d9
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.21.174
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+        id=\"0\" name=\"All Rights Reserved\" url=\"https://www.flickrhelp.com/hc/en-us/articles/10710266545556-Using-Flickr-images-shared-by-other-members\"
+        />\n\t<license id=\"4\" name=\"Attribution License\" url=\"https://creativecommons.org/licenses/by/2.0/\"
+        />\n\t<license id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+        />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+        url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license
+        id=\"2\" name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+        />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+        url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license
+        id=\"5\" name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+        />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+        />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"https://www.usa.gov/government-copyright\"
+        />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+        />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+        />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:19:54 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 8dbddccb44fea3c0ae7cceef434a136a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - GxTS8jmyC-ummWJyj3CdbNINjQZ2cNzJxQkyyEWOtLr7xCYkvI51Jw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '1360'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-681358da-382c9d816851c9347ab43735
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.38.162
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/TestGetLicenseHistory.test_photo_with_changed_license.yml
+++ b/tests/fixtures/cassettes/TestGetLicenseHistory.test_photo_with_changed_license.yml
@@ -1,0 +1,228 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getLicenseHistory&photo_id=54450311696
+  response:
+    body:
+      string: '<?xml version="1.0" encoding="utf-8" ?>
+
+        <rsp stat="ok">
+
+        <license_history date_change="1744598090" old_license="All Rights Reserved"
+        old_license_url="https://www.flickrhelp.com/hc/en-us/articles/10710266545556-Using-Flickr-images-shared-by-other-members"
+        new_license="Public Domain Mark" new_license_url="https://creativecommons.org/publicdomain/mark/1.0/"
+        />
+
+        <license_history date_change="1744905505" old_license="Public Domain Mark"
+        old_license_url="https://creativecommons.org/publicdomain/mark/1.0/" new_license="No
+        known copyright restrictions" new_license_url="https://www.flickr.com/commons/usage/"
+        />
+
+        </rsp>
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:12:56 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 5bbfbddc054a85758022c325fb08071e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - SPidPGtiyP0k4NR-kloURC2snjyK5URwJ-fA96A6DUCfuUQsP-6t7g==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '615'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:12:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:12:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-68135738-16a022cc6c5d635f770e13c9
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.43.60
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+        id=\"0\" name=\"All Rights Reserved\" url=\"https://www.flickrhelp.com/hc/en-us/articles/10710266545556-Using-Flickr-images-shared-by-other-members\"
+        />\n\t<license id=\"4\" name=\"Attribution License\" url=\"https://creativecommons.org/licenses/by/2.0/\"
+        />\n\t<license id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+        />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+        url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license
+        id=\"2\" name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+        />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+        url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license
+        id=\"5\" name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+        />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+        />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"https://www.usa.gov/government-copyright\"
+        />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+        />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+        />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:19:53 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 cebcb0d17c62ea30e361587bfe114ca0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - jfmF7M6-Yf64Nnh8uWt3UZBbm75OiRzvpoUrS0Xt6j2ZrntRZlZ1pQ==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '1360'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:53 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:53 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-681358d9-276fb9250aefda68694261c8
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.16.101
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=54450311696
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photo
+        id=\"54450311696\" secret=\"24280eeefa\" server=\"65535\" farm=\"66\" dateuploaded=\"1744597680\"
+        isfavorite=\"0\" license=\"7\" safety_level=\"0\" rotation=\"0\" originalsecret=\"aebbb52027\"
+        originalformat=\"jpg\" views=\"381\" media=\"photo\">\n\t<owner nsid=\"201909310@N04\"
+        username=\"Auckland War Memorial Museum T\u0101maki Paenga Hira\" realname=\"Auckland
+        Museum Commons\" location=\"\" iconserver=\"65535\" iconfarm=\"66\" path_alias=\"aucklandmuseum_commons\">\n\t\t<gift
+        gift_eligible=\"\" new_flow=\"1\" />\n\t</owner>\n\t<title>[Portrait of a
+        man holding the jaw of a shark]</title>\n\t<description>This photograph was
+        taken by Tudor Washington Collins (b.1898, d.1970), possibly in the 1940s.\n\nThis
+        scene depicts a man standing in the center of the image, holding up a jaw
+        (likely shark) with his head positioned in the middle of it.\n\nThe photographic
+        medium is gelatin dry plate negative, measuring 82 mm x 107 mm (1/4 plate),
+        on glass. It is classified under negatives/photographs/AAT Visual Works.\n\nCredit:
+        Shared by Auckland War Memorial Museum, T\u0101maki Paenga  Hira, as part
+        of the Tudor Collins collection. \nRights: No known copyright restrictions.
+        \nReference: PH-2013-7-TC-B141-03.\n\nFor more details, please visit: &lt;a
+        href=&quot;https://www.aucklandmuseum.com/discover/collections/record/1058670&quot;
+        rel=&quot;noreferrer nofollow&quot;&gt;www.aucklandmuseum.com/discover/collections/record/1058670&lt;/a&gt;</description>\n\t<visibility
+        ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\n\t<dates posted=\"1744597680\"
+        taken=\"2013-12-17 14:37:16\" takengranularity=\"0\" takenunknown=\"0\" lastupdate=\"1744905506\"
+        />\n\t<editability cancomment=\"0\" canaddmeta=\"0\" />\n\t<publiceditability
+        cancomment=\"1\" canaddmeta=\"1\" />\n\t<usage candownload=\"1\" canblog=\"0\"
+        canprint=\"0\" canshare=\"1\" />\n\t<comments>0</comments>\n\t<notes />\n\t<people
+        haspeople=\"0\" />\n\t<tags>\n\t\t<tag id=\"201877171-54450311696-2776\" author=\"201909310@N04\"
+        authorname=\"Auckland War Memorial Museum T\u0101maki Paenga Hira\" raw=\"Fishing\"
+        machine_tag=\"0\">fishing</tag>\n\t\t<tag id=\"201877171-54450311696-116\"
+        author=\"201909310@N04\" authorname=\"Auckland War Memorial Museum T\u0101maki
+        Paenga Hira\" raw=\"Trip\" machine_tag=\"0\">trip</tag>\n\t</tags>\n\t<urls>\n\t\t<url
+        type=\"photopage\">https://www.flickr.com/photos/aucklandmuseum_commons/54450311696/</url>\n\t</urls>\n</photo>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:25:26 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 55bef38e734117ff8ff4a83214717dc8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - rScVJNX8UtpvuX92HDe4rPnipdkg1Mv5v2r_J3VyKT0aCeUBrjOE3w==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '2331'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:25:26 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-68135a26-79ee32ba129ceed31eb2f011
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.16.101
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/TestGetLicenseHistory.test_photo_with_initial_license.yml
+++ b/tests/fixtures/cassettes/TestGetLicenseHistory.test_photo_with_initial_license.yml
@@ -1,0 +1,138 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getLicenseHistory&photo_id=3948976954
+  response:
+    body:
+      string: '<?xml version="1.0" encoding="utf-8" ?>
+
+        <rsp stat="ok">
+
+        <license_history date_change="1253741816" old_license="No known copyright
+        restrictions" old_license_url="https://www.flickr.com/commons/usage/" new_license=""
+        new_license_url="" />
+
+        </rsp>
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:12:56 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 f60de1480a12e102280c50972fa2a8e8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 95_H6zrOgWmaXlyzqTXzFgqGLMmhJI7R5OJ0bG7vJN2HJBf4kf_5Yw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '244'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:12:55 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:12:55 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-68135737-09d5a6e03d6a03c552fb1b2f
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.21.174
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+        id=\"0\" name=\"All Rights Reserved\" url=\"https://www.flickrhelp.com/hc/en-us/articles/10710266545556-Using-Flickr-images-shared-by-other-members\"
+        />\n\t<license id=\"4\" name=\"Attribution License\" url=\"https://creativecommons.org/licenses/by/2.0/\"
+        />\n\t<license id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+        />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+        url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license
+        id=\"2\" name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+        />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+        url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license
+        id=\"5\" name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+        />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+        />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"https://www.usa.gov/government-copyright\"
+        />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+        />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+        />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:18:35 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 5e8927f6dbbe16e857124daf8548aeb2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - teIKWAgq9YG4HLSgW8UsPAqhSx-n9YsazNf7VMNpxJoPnXw31_KJpA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '1360'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:18:35 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:18:35 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-6813588b-10023aaa52b26b3b67fbda12
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.14.139
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/TestGetLicenseHistory.test_photo_with_single_license_change.yml
+++ b/tests/fixtures/cassettes/TestGetLicenseHistory.test_photo_with_single_license_change.yml
@@ -1,0 +1,208 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getLicenseHistory&photo_id=54049228596
+  response:
+    body:
+      string: '<?xml version="1.0" encoding="utf-8" ?>
+
+        <rsp stat="ok">
+
+        <license_history date_change="1746098108" old_license="Attribution License"
+        old_license_url="https://creativecommons.org/licenses/by/2.0/" new_license="Attribution-ShareAlike
+        License" new_license_url="https://creativecommons.org/licenses/by-sa/2.0/"
+        />
+
+        </rsp>
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:16:05 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 1cc3fb840bf0d635b4ec2fb2c19ca094.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - -d976lX7hscnvb2q2SlMvBmx0YGAniW--ncEbu1ntkw61PSGLuiEaw==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '316'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:16:05 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:16:05 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-681357f5-2de5a12a0abb9e25771b2e62
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.14.139
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+        id=\"0\" name=\"All Rights Reserved\" url=\"https://www.flickrhelp.com/hc/en-us/articles/10710266545556-Using-Flickr-images-shared-by-other-members\"
+        />\n\t<license id=\"4\" name=\"Attribution License\" url=\"https://creativecommons.org/licenses/by/2.0/\"
+        />\n\t<license id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+        />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+        url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license
+        id=\"2\" name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+        />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+        url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license
+        id=\"5\" name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+        />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+        />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"https://www.usa.gov/government-copyright\"
+        />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+        />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+        />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:19:53 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 40e3ed7c6b85417046e956c87e47596a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mzlDWRJZWiFf8QMqwiKCEcsqh9VMH99CIl2HWVObbzeqT81idB_kOg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '1360'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:53 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:19:53 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-681358d9-0797715767eca33b72d84c0e
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.12.14
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=54049228596
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photo
+        id=\"54049228596\" secret=\"45729b2e8c\" server=\"65535\" farm=\"66\" dateuploaded=\"1728299873\"
+        isfavorite=\"0\" license=\"5\" safety_level=\"0\" rotation=\"0\" originalsecret=\"cf14dcc67e\"
+        originalformat=\"jpg\" views=\"15\" media=\"photo\">\n\t<owner nsid=\"199258389@N04\"
+        username=\"alexwlchan\" realname=\"\" location=\"\" iconserver=\"65535\" iconfarm=\"66\"
+        path_alias=\"alexwlchan\">\n\t\t<gift gift_eligible=\"1\" new_flow=\"1\">\n\t\t\t<eligible_durations
+        />\n\t\t\t<eligible_durations />\n\t\t\t<eligible_durations />\n\t\t</gift>\n\t</owner>\n\t<title>One
+        of Antwerp&#039;s early documents</title>\n\t<description />\n\t<visibility
+        ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\n\t<dates posted=\"1728299873\"
+        taken=\"2024-09-20 14:37:31\" takengranularity=\"0\" takenunknown=\"0\" lastupdate=\"1746098108\"
+        />\n\t<editability cancomment=\"0\" canaddmeta=\"0\" />\n\t<publiceditability
+        cancomment=\"1\" canaddmeta=\"0\" />\n\t<usage candownload=\"1\" canblog=\"0\"
+        canprint=\"0\" canshare=\"1\" />\n\t<comments>0</comments>\n\t<notes />\n\t<people
+        haspeople=\"0\" />\n\t<tags />\n\t<urls>\n\t\t<url type=\"photopage\">https://www.flickr.com/photos/alexwlchan/54049228596/</url>\n\t</urls>\n</photo>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Thu, 01 May 2025 11:25:26 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 55bef38e734117ff8ff4a83214717dc8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - RmDk7cmdMCwpX7gwI4yxKWG0TekljWeqBfQS4dbpyOV1kOHAOhiBYg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '1154'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 31-May-2025 11:25:26 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-68135a25-08d67f137d0af7811bfeaf60
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.32.44
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
This is a precursor to https://github.com/Flickr-Foundation/data-lifeboat/issues/19, and just a generally useful thing to have.