### PR TITLE
Improve the error handling for the sizes of non-existent photos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.3.1 - 2025-05-02
+
+If you call `get_single_photo_sizes()` for a photo that doesn't exist, you now get a `ResourceNotFound` exception instead of `UnrecognisedFlickrApiException`.
+
 ## v3.3 - 2025-05-01
 
 Add a new method `get_license_history(photo_id)`, which returns the license history of a photo with our nicely-typed `License` model.

--- a/src/flickr_api/__init__.py
+++ b/src/flickr_api/__init__.py
@@ -13,7 +13,7 @@ from .exceptions import (
 )
 
 
-__version__ = "3.3"
+__version__ = "3.3.1"
 
 
 __all__ = [

--- a/src/flickr_api/api/single_photo_methods.py
+++ b/src/flickr_api/api/single_photo_methods.py
@@ -239,7 +239,11 @@ class SinglePhotoMethods(LicenseMethods):
         This uses the flickr.photos.getSizes API.
         """
         sizes_resp = self.call(
-            method="flickr.photos.getSizes", params={"photo_id": photo_id}
+            method="flickr.photos.getSizes",
+            params={"photo_id": photo_id},
+            exceptions={
+                "1": ResourceNotFound(f"Could not find photo with ID: {photo_id!r}"),
+            },
         )
 
         # The getSizes response is a blob of XML of the form:

--- a/tests/api/test_single_photo_methods.py
+++ b/tests/api/test_single_photo_methods.py
@@ -278,6 +278,20 @@ class TestGetSinglePhoto:
         ]
 
 
+class TestGetSinglePhotoSizes:
+    """
+    Tests for `SinglePhotoMethods.get_single_photo_sizes`.
+    """
+
+    def test_non_existent_photo_is_error(self, api: FlickrApi) -> None:
+        """
+        If a photo doesn't exist, then getting the sizes throws
+        a ResourceNotFound.
+        """
+        with pytest.raises(ResourceNotFound):
+            api.get_single_photo_sizes(photo_id="does_not_exist")
+
+
 class TestIsPhotoDeleted:
     """
     Tests for ``SinglePhotoMethods.is_photo_deleted``.

--- a/tests/fixtures/cassettes/TestGetSinglePhotoSizes.test_non_existent_photo_is_error.yml
+++ b/tests/fixtures/cassettes/TestGetSinglePhotoSizes.test_non_existent_photo_is_error.yml
@@ -1,0 +1,59 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
+        hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=does_not_exist
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"fail\">\n\t<err
+        code=\"1\" msg=\"Photo not found\" />\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 02 May 2025 09:02:20 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 063bfb014e66ef670fc62ff044660cf2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - KH8cxe-1rUV338wR03TWdMOApFxf3KBMzYZNoXBBSzHaR-7214abYQ==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-length:
+      - '105'
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 01-Jun-2025 09:02:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 01-Jun-2025 09:02:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-68148a1b-1b0314cd6a557ac644ffeccf
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.47.245
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
I spotted this while writing a script to backfill some photo sizes.

This method used to be private, only called as part of `get_photo_info()`, so it was guaranteed that the photo would exist by the time it was called. But now it's a public method, that's no longer the case!