### PR TITLE
Return information about photo permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.4 - 2025-05-02
+
+Return information about photo permissions: can you download, share, or print a photo.
+
 ## v3.3.1 - 2025-05-02
 
 If you call `get_single_photo_sizes()` for a photo that doesn't exist, you now get a `ResourceNotFound` exception instead of `UnrecognisedFlickrApiException`.

--- a/src/flickr_api/__init__.py
+++ b/src/flickr_api/__init__.py
@@ -13,7 +13,7 @@ from .exceptions import (
 )
 
 
-__version__ = "3.3.1"
+__version__ = "3.4"
 
 
 __all__ = [

--- a/src/flickr_api/api/single_photo_methods.py
+++ b/src/flickr_api/api/single_photo_methods.py
@@ -21,6 +21,7 @@ from ..models import (
     SinglePhoto,
     Size,
     Tag,
+    Usage,
     Visibility,
 )
 from ..parsers import (
@@ -184,6 +185,22 @@ class SinglePhotoMethods(LicenseMethods):
             "is_family": visibility_elem.attrib["isfamily"] == "1",
         }
 
+        # Get usage information about the photo.
+        #
+        # This is returned in the form:
+        #
+        #     <usage candownload="0" canblog="0" canprint="0" canshare="0"/>
+        #
+        # fmt: off
+        usage_elem = find_required_elem(photo_elem, path="usage")
+        usage: Usage = {
+            "can_download": usage_elem.attrib["candownload"] == "1",
+            "can_blog":     usage_elem.attrib["canblog"]     == "1",
+            "can_print":    usage_elem.attrib["canprint"]    == "1",
+            "can_share":    usage_elem.attrib["canshare"]    == "1",
+        }
+        # fmt: on
+
         assert photo_elem.attrib["media"] in {"photo", "video"}
         media_type = typing.cast(MediaType, photo_elem.attrib["media"])
 
@@ -210,6 +227,7 @@ class SinglePhotoMethods(LicenseMethods):
             "count_views": count_views,
             "url": url,
             "visibility": visibility,
+            "usage": usage,
         }
 
     def get_single_photo_info(self, *, photo_id: str) -> SinglePhotoInfo:

--- a/src/flickr_api/models/__init__.py
+++ b/src/flickr_api/models/__init__.py
@@ -10,6 +10,7 @@ from .photo import (
     NamedLocation,
     NumericLocation,
     Rotation,
+    Usage,
 )
 from .sizes import Size
 from .users import User, UserInfo
@@ -30,6 +31,7 @@ __all__ = [
     "PhotoContext",
     "Rotation",
     "Size",
+    "Usage",
     "User",
     "UserInfo",
     "Visibility",
@@ -111,7 +113,7 @@ class SinglePhotoInfo(typing.TypedDict):
     description: str | None
     tags: list[str]
     machine_tags: MachineTags
-    raw_tags: typing.NotRequired[list[Tag]]
+    raw_tags: list[Tag]
 
     date_posted: datetime
     date_taken: DateTaken | None
@@ -120,7 +122,8 @@ class SinglePhotoInfo(typing.TypedDict):
     count_comments: int
     count_views: int
 
-    visibility: typing.NotRequired[Visibility]
+    visibility: Visibility
+    usage: Usage
 
     url: str
 

--- a/src/flickr_api/models/photo.py
+++ b/src/flickr_api/models/photo.py
@@ -41,3 +41,14 @@ class Location(NumericLocation, NamedLocation):
     """
     Both numeric and named information about a location.
     """
+
+
+class Usage(typing.TypedDict):
+    """
+    Describes the permissions that can be set on a photo.
+    """
+
+    can_download: bool
+    can_blog: bool
+    can_print: bool
+    can_share: bool

--- a/tests/fixtures/api_responses/32812033543.json
+++ b/tests/fixtures/api_responses/32812033543.json
@@ -240,6 +240,12 @@
   ],
   "title": "Puppy Kisses",
   "url": "https://www.flickr.com/photos/coast_guard/32812033543/",
+  "usage": {
+    "can_download": true,
+    "can_blog": false,
+    "can_print": false,
+    "can_share": true
+  },
   "visibility": {
     "is_public": true,
     "is_friend": false,


### PR DESCRIPTION
This is for Data Lifeboat; it's a more reliable way to determine if the owner has disabled photo downloads than looking at the `flickr.photos.getSizes` response.