### PR TITLE
Use `pytest-xdist` to run the test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,5 @@ jobs:
 
     - name: Run tests
       run: |
-        coverage run -m pytest tests
+        pytest tests
         coverage report

--- a/dev_requirements.in
+++ b/dev_requirements.in
@@ -5,6 +5,7 @@ build
 interrogate
 mypy
 pytest-cov
+pytest-xdist
 ruff
 twine
 types-Authlib

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -33,6 +33,8 @@ cryptography==44.0.2
     #   types-authlib
 docutils==0.21.2
     # via readme-renderer
+execnet==2.1.1
+    # via pytest-xdist
 flickr-url-parser==1.11.0
     # via flickr-photos-api
 h11==0.14.0
@@ -109,11 +111,14 @@ pytest==8.3.5
     # via
     #   pytest-cov
     #   pytest-vcr
+    #   pytest-xdist
     #   silver-nitrate
 pytest-cov==6.1.1
     # via -r dev_requirements.in
 pytest-vcr==1.0.2
     # via silver-nitrate
+pytest-xdist==3.6.1
+    # via -r dev_requirements.in
 pyyaml==6.0.2
     # via vcrpy
 readme-renderer==44.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ exclude_also = [
 
 [tool.pytest.ini_options]
 filterwarnings = ["error"]
+addopts = [
+  "--numprocesses=auto",
+]
 
 [tool.mypy]
 mypy_path = "src"


### PR DESCRIPTION
This allows pytest to distribute tests across multiple CPU cores, which makes the tests much faster -- approximately a 3x speedup on my machine.