### PR TITLE
Retry downloads that return 5xx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.10.1 - 2025-06-18
+
+When downloading files with `download_file()`, retry HTTP 502 and other 5xx errors from Flickr.com.
+
 ## v3.10 - 2025-06-17
 
 Add a new method `get_profile()` which returns profile information about a user.

--- a/src/flickr_api/__init__.py
+++ b/src/flickr_api/__init__.py
@@ -14,7 +14,7 @@ from .exceptions import (
 )
 
 
-__version__ = "3.10"
+__version__ = "3.10.1"
 
 
 __all__ = [

--- a/src/flickr_api/downloader.py
+++ b/src/flickr_api/downloader.py
@@ -20,14 +20,13 @@ def is_retryable(exc: BaseException) -> bool:
     or transient errors that might return a different result),or
     False otherwise.
     """
-    if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code in {
-        403,
-        429,
-    }:
-        return True  # pragma: no cover
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
 
-    if isinstance(exc, httpx.RemoteProtocolError):
-        return True  # pragma: no cover
+        return status_code in {403, 429} or status_code >= 500
+
+    if isinstance(exc, httpx.RemoteProtocolError):  # pragma: no cover
+        return True
 
     # We can retry a download if it timed out.
     #
@@ -38,7 +37,7 @@ def is_retryable(exc: BaseException) -> bool:
     ):  # pragma: no cover
         return True
 
-    return False
+    return False  # pragma: no cover
 
 
 class DownloadedFile(typing.TypedDict):


### PR DESCRIPTION
We got a couple of HTTP 502 errors in Data Lifeboat yesterday, because we don't retry that sort of error. Oops!