### PR TITLE
Retry `httpx.ConnectTimeout` exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v3.11 - 2025-06-19
 
+Add support for Creative Commons 4.0 licenses, which are [now supported on Flickr.com](https://blog.flickr.net/en/2025/06/18/creative-commons-4-0-has-arrived-on-flickr/).
+
 ## v3.10.1 - 2025-06-18
 
 When downloading files with `download_file()`, retry HTTP 502 and other 5xx errors from Flickr.com.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.11.1 - 2025-06-20
+
+When connecting to the Flickr API, retry `httpx.ConnectTimeout` exceptions.
+
 ## v3.11 - 2025-06-19
 
 Add support for Creative Commons 4.0 licenses, which are [now supported on Flickr.com](https://blog.flickr.net/en/2025/06/18/creative-commons-4-0-has-arrived-on-flickr/).

--- a/src/flickr_api/__init__.py
+++ b/src/flickr_api/__init__.py
@@ -14,7 +14,7 @@ from .exceptions import (
 )
 
 
-__version__ = "3.11"
+__version__ = "3.11.1"
 
 
 __all__ = [

--- a/src/flickr_api/api/base.py
+++ b/src/flickr_api/api/base.py
@@ -71,7 +71,7 @@ def is_retryable(exc: BaseException) -> bool:
     if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500:
         return True
 
-    if isinstance(exc, httpx.ReadTimeout):
+    if isinstance(exc, (httpx.ConnectTimeout, httpx.ReadTimeout)):
         return True
 
     if isinstance(exc, InvalidXmlException):


### PR DESCRIPTION
This caused a failure in the Commons Explorer yesterday, so let's retry this exception also: https://commons.flickr.org/admin/scheduled_tasks/logs/bpnkpdff