### PR TITLE
Skip a test that fails if FLICKR_API_KEY is set

### DIFF
--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -2,11 +2,17 @@
 Tests for `flickr_api.fixtures`.
 """
 
+import os
+
 import pytest
 
 from flickr_api import FlickrApi
 
 
+@pytest.mark.skipif(
+    "FLICKR_API_KEY" in os.environ,
+    reason="This test relies on the FLICKR_API_KEY env var not being set",
+)
 def test_using_flickr_api_fixture_without_env_var_is_error(
     flickr_api: FlickrApi,
 ) -> None:


### PR DESCRIPTION
If you run this test while you have FLICKR_API_KEY set, previously it would make the real API call and the test would fail because it expects to get a configuration error. By skipping the test when the env var is set, we avoid creating spurious VCR cassettes and getting unexpected failures.